### PR TITLE
fix: add || true to npm update commands to prevent set -e exit

### DIFF
--- a/scripts/setup-local-ubuntu.sh
+++ b/scripts/setup-local-ubuntu.sh
@@ -557,7 +557,7 @@ install_ai_tools() {
       echo "  ✅ Codex CLI インストール完了"
     else
       echo "  ℹ️  Codex CLI を最新版に更新中..."
-      npm update -g @openai/codex >/dev/null 2>&1
+      npm update -g @openai/codex >/dev/null 2>&1 || true
       echo "  ⏭️  Codex CLI は最新版です"
     fi
   fi
@@ -593,7 +593,7 @@ install_ai_tools() {
       echo "  ✅ Gemini CLI インストール完了"
     else
       echo "  ℹ️  Gemini CLI を最新版に更新中..."
-      npm update -g @google/gemini-cli >/dev/null 2>&1
+      npm update -g @google/gemini-cli >/dev/null 2>&1 || true
       echo "  ⏭️  Gemini CLI は最新版です"
     fi
   fi


### PR DESCRIPTION
## Summary

- `scripts/setup-local-ubuntu.sh` の `npm update -g` コマンド（Codex CLI / Gemini CLI）に `|| true` を追加
- `set -e` 環境下で `npm update` が非ゼロ終了コードを返した場合にスクリプト全体が強制終了する問題を修正
- `claude update` / `copilot update` では既に `|| true` が付与されており、パターンを統一

## Test plan

- [ ] `setup-local-ubuntu.sh` が Codex CLI 更新チェックを通過して後続の処理に進むことを確認
- [ ] `bash -n` による構文チェックがパスすることを確認（済）
- [ ] `shellcheck` で新規エラーがないことを確認（済）