### PR TITLE
fix: prevent update commands from hanging on interactive prompts

### DIFF
--- a/scripts/setup-local-ubuntu.sh
+++ b/scripts/setup-local-ubuntu.sh
@@ -539,7 +539,7 @@ install_ai_tools() {
       echo "  ✅ Claude Code インストール完了"
     else
       echo "  ℹ️  Claude Code を最新版に更新中..."
-      claude update >/dev/null 2>&1 || true
+      claude update </dev/null >/dev/null 2>&1 || true
       echo "  ⏭️  Claude Code は最新版です ($(claude --version 2>/dev/null || echo '不明'))"
     fi
   fi
@@ -575,7 +575,7 @@ install_ai_tools() {
       echo "  ✅ GitHub Copilot CLI インストール完了"
     else
       echo "  ℹ️  GitHub Copilot CLI を最新版に更新中..."
-      copilot update >/dev/null 2>&1 || true
+      copilot update </dev/null >/dev/null 2>&1 || true
       echo "  ⏭️  GitHub Copilot CLI は最新版です ($(copilot --version 2>/dev/null || echo '不明'))"
     fi
   fi


### PR DESCRIPTION
## Summary

- `copilot update` が VS Code 拡張のラッパーバイナリ経由で実行される際、インタラクティブプロンプト (`Install GitHub Copilot CLI? [y/N]`) を出力してフリーズする問題を修正
- `claude update` と `copilot update` に `</dev/null` を追加し、stdin を閉じることでプロンプト待ちを防止
- stdout/stderr は既に `/dev/null` にリダイレクトされているため、プロンプトがユーザーに見えずフリーズの原因となっていた

## Test plan

- [ ] `setup-local-ubuntu.sh` が Copilot CLI 更新チェックを通過してフリーズしないことを確認
- [ ] `bash -n` による構文チェックがパスすることを確認（済）
- [ ] `shellcheck` で新規エラーがないことを確認（済）