### PR TITLE
fix: add timeout to copilot CLI commands to prevent shim hangs

### DIFF
--- a/scripts/setup-local-ubuntu.sh
+++ b/scripts/setup-local-ubuntu.sh
@@ -539,7 +539,7 @@ install_ai_tools() {
       echo "  ✅ Claude Code インストール完了"
     else
       echo "  ℹ️  Claude Code を最新版に更新中..."
-      claude update </dev/null >/dev/null 2>&1 || true
+      timeout 10 claude update </dev/null >/dev/null 2>&1 || true
       echo "  ⏭️  Claude Code は最新版です ($(claude --version 2>/dev/null || echo '不明'))"
     fi
   fi
@@ -575,8 +575,8 @@ install_ai_tools() {
       echo "  ✅ GitHub Copilot CLI インストール完了"
     else
       echo "  ℹ️  GitHub Copilot CLI を最新版に更新中..."
-      copilot update </dev/null >/dev/null 2>&1 || true
-      echo "  ⏭️  GitHub Copilot CLI は最新版です ($(copilot --version 2>/dev/null || echo '不明'))"
+      timeout 10 copilot update </dev/null >/dev/null 2>&1 || true
+      echo "  ⏭️  GitHub Copilot CLI は最新版です ($(timeout 5 copilot --version 2>/dev/null || echo '不明'))"
     fi
   fi
 
@@ -1279,7 +1279,7 @@ echo ""
 echo "  🤖 AIツール:"
 echo "    Claude Code:        $(claude --version 2>/dev/null || echo '未インストール')"
 echo "    Codex CLI:          $(codex --version 2>/dev/null || echo '未インストール')"
-echo "    GitHub Copilot CLI: $(copilot --version 2>/dev/null || echo '未インストール')"
+echo "    GitHub Copilot CLI: $(timeout 5 copilot --version 2>/dev/null || echo '未インストール')"
 echo "    Gemini CLI:         $(gemini --version 2>/dev/null || echo '未インストール')"
 echo ""
 echo "  🛠️ 開発補助ツール:"


### PR DESCRIPTION
## Summary

- VS Code の copilot 拡張が `~/.vscode-server/.../copilotCli/copilot` に shim スクリプトをインストールし、`command -v copilot` で検出される
- この shim は Node.js の `readline` でインタラクティブプロンプト (`Install GitHub Copilot CLI? ['y/N']`) を出すが、`readline.question()` は stdin が EOF でも Promise を解決しないためハングする
- `copilot update` と `copilot --version` の全呼び出しに `timeout` を追加してハングを防止
- `claude update` にも予防的に `timeout` を追加

## Test plan

- [ ] `setup-local-ubuntu.sh` が Copilot CLI セクションでフリーズせず進行することを確認
- [ ] バージョン表示セクション（スクリプト末尾）でフリーズしないことを確認
- [ ] `bash -n` 構文チェックがパス（済）
- [ ] `shellcheck` で新規エラーなし（済）