### PR TITLE
fix: detect VS Code copilot shim and skip it

### DIFF
--- a/scripts/setup-local-ubuntu.sh
+++ b/scripts/setup-local-ubuntu.sh
@@ -570,13 +570,16 @@ install_ai_tools() {
       any_installed=1
     }
 
-    if ! command -v copilot &>/dev/null; then
+    # VS Code 拡張の shim（~/.vscode-server/...）はスタンドアロン CLI ではないため除外
+    local copilot_path
+    copilot_path=$(command -v copilot 2>/dev/null || true)
+    if [ -z "$copilot_path" ] || [[ "$copilot_path" == *".vscode-server"* ]]; then
       curl -fsSL https://gh.io/copilot-install | bash
       echo "  ✅ GitHub Copilot CLI インストール完了"
     else
       echo "  ℹ️  GitHub Copilot CLI を最新版に更新中..."
       timeout 10 copilot update </dev/null >/dev/null 2>&1 || true
-      echo "  ⏭️  GitHub Copilot CLI は最新版です ($(timeout 5 copilot --version 2>/dev/null || echo '不明'))"
+      echo "  ⏭️  GitHub Copilot CLI は最新版です ($(copilot --version 2>/dev/null || echo '不明'))"
     fi
   fi
 
@@ -1279,7 +1282,7 @@ echo ""
 echo "  🤖 AIツール:"
 echo "    Claude Code:        $(claude --version 2>/dev/null || echo '未インストール')"
 echo "    Codex CLI:          $(codex --version 2>/dev/null || echo '未インストール')"
-echo "    GitHub Copilot CLI: $(timeout 5 copilot --version 2>/dev/null || echo '未インストール')"
+echo "    GitHub Copilot CLI: $([[ "$(command -v copilot 2>/dev/null)" == *".vscode-server"* ]] && echo '未インストール' || copilot --version 2>/dev/null || echo '未インストール')"
 echo "    Gemini CLI:         $(gemini --version 2>/dev/null || echo '未インストール')"
 echo ""
 echo "  🛠️ 開発補助ツール:"

--- a/scripts/setup-local-ubuntu.sh
+++ b/scripts/setup-local-ubuntu.sh
@@ -579,7 +579,7 @@ install_ai_tools() {
     else
       echo "  ℹ️  GitHub Copilot CLI を最新版に更新中..."
       timeout 10 copilot update </dev/null >/dev/null 2>&1 || true
-      echo "  ⏭️  GitHub Copilot CLI は最新版です ($(copilot --version 2>/dev/null || echo '不明'))"
+      echo "  ⏭️  GitHub Copilot CLI は最新版です ($(copilot --version 2>/dev/null | head -n1 || echo '不明'))"
     fi
   fi
 
@@ -1282,7 +1282,7 @@ echo ""
 echo "  🤖 AIツール:"
 echo "    Claude Code:        $(claude --version 2>/dev/null || echo '未インストール')"
 echo "    Codex CLI:          $(codex --version 2>/dev/null || echo '未インストール')"
-echo "    GitHub Copilot CLI: $([[ "$(command -v copilot 2>/dev/null)" == *".vscode-server"* ]] && echo '未インストール' || copilot --version 2>/dev/null || echo '未インストール')"
+echo "    GitHub Copilot CLI: $([[ "$(command -v copilot 2>/dev/null)" == *".vscode-server"* ]] && echo '未インストール' || copilot --version 2>/dev/null | head -n1 || echo '未インストール')"
 echo "    Gemini CLI:         $(gemini --version 2>/dev/null || echo '未インストール')"
 echo ""
 echo "  🛠️ 開発補助ツール:"

--- a/scripts/setup-local-ubuntu.sh
+++ b/scripts/setup-local-ubuntu.sh
@@ -284,7 +284,7 @@ install_node_environment() {
   echo "⚡ Volta をインストール中..."
   if ! command -v volta &>/dev/null; then
     # 注意: curl | bash パターンは公式のインストール方法（HTTPS使用）
-    curl https://get.volta.sh | bash
+    curl https://get.volta.sh | bash >/dev/null 2>&1
     # Volta のパスを即座に通す
     export VOLTA_HOME="$HOME/.volta"
     export PATH="$VOLTA_HOME/bin:$PATH"
@@ -535,7 +535,7 @@ install_ai_tools() {
     }
 
     if ! command -v claude &>/dev/null; then
-      curl -fsSL https://claude.ai/install.sh | bash
+      curl -fsSL https://claude.ai/install.sh | bash >/dev/null 2>&1
       echo "  ✅ Claude Code インストール完了"
     else
       echo "  ℹ️  Claude Code を最新版に更新中..."
@@ -574,7 +574,7 @@ install_ai_tools() {
     local copilot_path
     copilot_path=$(command -v copilot 2>/dev/null || true)
     if [ -z "$copilot_path" ] || [[ "$copilot_path" == *".vscode-server"* ]]; then
-      curl -fsSL https://gh.io/copilot-install | bash
+      curl -fsSL https://gh.io/copilot-install | bash >/dev/null 2>&1
       echo "  ✅ GitHub Copilot CLI インストール完了"
     else
       echo "  ℹ️  GitHub Copilot CLI を最新版に更新中..."


### PR DESCRIPTION
## Summary

- VS Code Copilot Chat 拡張が `~/.vscode-server/.../copilotCli/copilot` に shim を配置し、`command -v copilot` で検出されてしまう問題を修正
- shim のパスに `.vscode-server` が含まれるかチェックし、shim の場合は「未インストール」として扱いスタンドアロン CLI をインストールする
- バージョン表示セクションでも同様に shim を検出し、プロンプト文字列がバージョン表示に混入するのを防止

## 修正前の表示

```
GitHub Copilot CLI: Install GitHub Copilot CLI? ['y/N'] 未インストール
```

## 修正後の表示（shim のみの場合）

```
GitHub Copilot CLI: 未インストール
```

## Test plan

- [ ] VS Code shim のみ存在する環境でスタンドアロン CLI のインストールが実行されることを確認
- [ ] バージョン表示にプロンプト文字列が混入しないことを確認
- [ ] `bash -n` 構文チェックがパス（済）
- [ ] `shellcheck` で新規エラーなし（済）