### PR TITLE
feat: add scripts/update-tools.sh for batch tool updates

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -6,15 +6,16 @@ readonly REPO_NAME="wsl-dev-setup"
 readonly DEFAULT_REF="${WSL_DEV_SETUP_REF:-main}"
 
 usage() {
-    cat <<'EOF'
+  cat <<'EOF'
 Usage:
-  ./install.sh [zsh|local|all] [--ref <git-ref>]
-  curl -fsSL https://raw.githubusercontent.com/ozzy-labs/wsl-dev-setup/main/install.sh | bash -s -- [zsh|local|all] [--ref <git-ref>]
+  ./install.sh [zsh|local|all|update] [--ref <git-ref>]
+  curl -fsSL https://raw.githubusercontent.com/ozzy-labs/wsl-dev-setup/main/install.sh | bash -s -- [zsh|local|all|update] [--ref <git-ref>]
 
 Commands:
-  zsh   Run scripts/setup-zsh-ubuntu.sh
-  local Run scripts/setup-local-ubuntu.sh
-  all   Run both scripts in order (default)
+  zsh     Run scripts/setup-zsh-ubuntu.sh
+  local   Run scripts/setup-local-ubuntu.sh
+  all     Run both setup scripts in order (default)
+  update  Run scripts/update-tools.sh (batch-update mise/uv/npm managed tools)
 
 Options:
   --ref <git-ref>  Download scripts from the specified branch, tag, or commit
@@ -22,123 +23,126 @@ Options:
 
 Environment:
   WSL_DEV_SETUP_REF  Default git ref to download when running remotely
-  SETUP_LOG          Passed through to the underlying setup script(s)
+  SETUP_LOG          Passed through to the underlying setup/update script(s)
 EOF
 }
 
 log() {
-    printf '%s\n' "$*"
+  printf '%s\n' "$*"
 }
 
 die() {
-    printf 'Error: %s\n' "$*" >&2
-    exit 1
+  printf 'Error: %s\n' "$*" >&2
+  exit 1
 }
 
 require_command() {
-    command -v "$1" >/dev/null 2>&1 || die "Required command not found: $1"
+  command -v "$1" >/dev/null 2>&1 || die "Required command not found: $1"
 }
 
 download_to_stdout() {
-    if command -v curl >/dev/null 2>&1; then
-        curl -fsSL "$1"
-        return
-    fi
+  if command -v curl >/dev/null 2>&1; then
+    curl -fsSL "$1"
+    return
+  fi
 
-    if command -v wget >/dev/null 2>&1; then
-        wget -qO- "$1"
-        return
-    fi
+  if command -v wget >/dev/null 2>&1; then
+    wget -qO- "$1"
+    return
+  fi
 
-    die "curl or wget is required to download setup files"
+  die "curl or wget is required to download setup files"
 }
 
 run_script() {
-    local script_path="$1"
+  local script_path="$1"
 
-    [ -x "$script_path" ] || chmod +x "$script_path"
-    log ""
-    log "==> Running $(basename "$script_path")"
-    "$script_path"
+  [ -x "$script_path" ] || chmod +x "$script_path"
+  log ""
+  log "==> Running $(basename "$script_path")"
+  "$script_path"
 }
 
 run_local() {
-    local target="$1"
-    local base_dir="$2"
+  local target="$1"
+  local base_dir="$2"
 
-    case "$target" in
-        zsh)
-            run_script "$base_dir/scripts/setup-zsh-ubuntu.sh"
-            ;;
-        local)
-            run_script "$base_dir/scripts/setup-local-ubuntu.sh"
-            ;;
-        all)
-            run_script "$base_dir/scripts/setup-zsh-ubuntu.sh"
-            run_script "$base_dir/scripts/setup-local-ubuntu.sh"
-            ;;
-        *)
-            die "Unknown command: $target"
-            ;;
-    esac
+  case "$target" in
+  zsh)
+    run_script "$base_dir/scripts/setup-zsh-ubuntu.sh"
+    ;;
+  local)
+    run_script "$base_dir/scripts/setup-local-ubuntu.sh"
+    ;;
+  all)
+    run_script "$base_dir/scripts/setup-zsh-ubuntu.sh"
+    run_script "$base_dir/scripts/setup-local-ubuntu.sh"
+    ;;
+  update)
+    run_script "$base_dir/scripts/update-tools.sh"
+    ;;
+  *)
+    die "Unknown command: $target"
+    ;;
+  esac
 }
 
 main() {
-    local target="all"
-    local ref="$DEFAULT_REF"
+  local target="all"
+  local ref="$DEFAULT_REF"
 
-    while [ "$#" -gt 0 ]; do
-        case "$1" in
-            zsh|local|all)
-                target="$1"
-                ;;
-            --ref)
-                [ "$#" -ge 2 ] || die "--ref requires a value"
-                ref="$2"
-                shift
-                ;;
-            -h|--help)
-                usage
-                exit 0
-                ;;
-            *)
-                die "Unknown argument: $1"
-                ;;
-        esac
-        shift
-    done
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+    zsh | local | all | update)
+      target="$1"
+      ;;
+    --ref)
+      [ "$#" -ge 2 ] || die "--ref requires a value"
+      ref="$2"
+      shift
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      die "Unknown argument: $1"
+      ;;
+    esac
+    shift
+  done
 
-    if [ -n "${BASH_SOURCE[0]:-}" ]; then
-        local source_path
-        source_path="${BASH_SOURCE[0]}"
-        if [ -f "$source_path" ]; then
-            local script_dir
-            script_dir="$(cd "$(dirname "$source_path")" && pwd)"
-            if [ -f "$script_dir/scripts/setup-zsh-ubuntu.sh" ] && [ -f "$script_dir/scripts/setup-local-ubuntu.sh" ]; then
-                run_local "$target" "$script_dir"
-                return
-            fi
-        fi
+  if [ -n "${BASH_SOURCE[0]:-}" ]; then
+    local source_path
+    source_path="${BASH_SOURCE[0]}"
+    if [ -f "$source_path" ]; then
+      local script_dir
+      script_dir="$(cd "$(dirname "$source_path")" && pwd)"
+      if [ -f "$script_dir/scripts/setup-zsh-ubuntu.sh" ] && [ -f "$script_dir/scripts/setup-local-ubuntu.sh" ]; then
+        run_local "$target" "$script_dir"
+        return
+      fi
     fi
+  fi
 
-    require_command tar
-    require_command mktemp
+  require_command tar
+  require_command mktemp
 
-    local tmp_dir
-    tmp_dir="$(mktemp -d)"
-    trap 'rm -rf "$tmp_dir"' EXIT
+  local tmp_dir
+  tmp_dir="$(mktemp -d)"
+  trap 'rm -rf "$tmp_dir"' EXIT
 
-    local archive_url
-    archive_url="https://codeload.github.com/${REPO_OWNER}/${REPO_NAME}/tar.gz/${ref}"
+  local archive_url
+  archive_url="https://codeload.github.com/${REPO_OWNER}/${REPO_NAME}/tar.gz/${ref}"
 
-    log "==> Downloading ${REPO_OWNER}/${REPO_NAME} (${ref})"
-    download_to_stdout "$archive_url" | tar -xzf - -C "$tmp_dir"
+  log "==> Downloading ${REPO_OWNER}/${REPO_NAME} (${ref})"
+  download_to_stdout "$archive_url" | tar -xzf - -C "$tmp_dir"
 
-    local extracted_dir
-    extracted_dir="$(find "$tmp_dir" -mindepth 1 -maxdepth 1 -type d | sort | head -n 1)"
-    [ -n "$extracted_dir" ] || die "Failed to unpack downloaded archive"
+  local extracted_dir
+  extracted_dir="$(find "$tmp_dir" -mindepth 1 -maxdepth 1 -type d | sort | head -n 1)"
+  [ -n "$extracted_dir" ] || die "Failed to unpack downloaded archive"
 
-    run_local "$target" "$extracted_dir"
+  run_local "$target" "$extracted_dir"
 }
 
 main "$@"

--- a/scripts/update-tools.sh
+++ b/scripts/update-tools.sh
@@ -1,0 +1,134 @@
+#!/bin/bash
+# =======================================================================
+# update-tools.sh
+# -----------------------------------------------------------------------
+# mise / uv tool / npm グローバル経由で導入済みツールを一括更新する。
+# setup-local-ubuntu.sh のハイブリッドメンテ方針を踏襲:
+#   - mise: mise self-update + mise upgrade
+#   - uv tool: uv tool upgrade --all（markitdown 等）
+#   - npm global: AI エージェント CLI（Codex / Gemini）
+#   - Native installer: Claude Code / GitHub Copilot CLI
+#
+# Usage:
+#   ./scripts/update-tools.sh            # 通常実行
+#   ./scripts/update-tools.sh --dry-run  # 実際の更新は行わず、対象だけ表示
+#   SETUP_LOG=1 ./scripts/update-tools.sh
+#
+# 冪等で、任意のツールが未インストールでも失敗しない設計。
+# =======================================================================
+set -e
+
+DRY_RUN=0
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+  --dry-run | -n)
+    DRY_RUN=1
+    ;;
+  -h | --help)
+    sed -n '2,18p' "$0"
+    exit 0
+    ;;
+  *)
+    echo "⚠️  未知の引数: $1" >&2
+    exit 1
+    ;;
+  esac
+  shift
+done
+
+# ログ出力機能（SETUP_LOG 環境変数が設定されている場合）
+if [ -n "$SETUP_LOG" ]; then
+  if [ "$SETUP_LOG" = "1" ] || [ "$SETUP_LOG" = "true" ]; then
+    LOG_FILE="$HOME/update-tools-$(date +%Y%m%d-%H%M%S).log"
+  else
+    LOG_FILE="$SETUP_LOG"
+  fi
+  exec > >(tee -a "$LOG_FILE") 2>&1
+  echo "ℹ️  ログを $LOG_FILE に記録します"
+fi
+
+MISE_BIN="$HOME/.local/bin/mise"
+
+run_or_preview() {
+  local description="$1"
+  shift
+  if [ "$DRY_RUN" = "1" ]; then
+    printf '  [dry-run] %s\n' "$description"
+    printf '            $ %s\n' "$*"
+  else
+    echo "  ▶ $description"
+    "$@" || echo "    ⚠️  コマンドが失敗しました: $*（続行します）"
+  fi
+}
+
+echo "🔄 ツール一括更新を開始 ($([ "$DRY_RUN" = "1" ] && echo 'dry-run' || echo 'live'))"
+echo ""
+
+# -----------------------------------------------------------------------
+# 1. mise 本体 + mise 管理下のツール
+# -----------------------------------------------------------------------
+if [ -x "$MISE_BIN" ]; then
+  echo "⚡ mise の更新:"
+  run_or_preview "mise 本体の自己更新" "$MISE_BIN" self-update -y
+  run_or_preview "mise 管理ツールの最新化" "$MISE_BIN" upgrade
+  run_or_preview "シムの再生成" "$MISE_BIN" reshim
+else
+  echo "⏭️  mise が未インストールのためスキップ"
+fi
+
+echo ""
+
+# -----------------------------------------------------------------------
+# 2. uv tool（markitdown など）
+# -----------------------------------------------------------------------
+if command -v uv &>/dev/null; then
+  echo "🐍 uv tool の更新:"
+  run_or_preview "uv tool upgrade --all" uv tool upgrade --all
+else
+  echo "⏭️  uv が未インストールのためスキップ"
+fi
+
+echo ""
+
+# -----------------------------------------------------------------------
+# 3. npm グローバル（AI エージェント CLI のうち npm 配布分）
+# -----------------------------------------------------------------------
+if command -v npm &>/dev/null; then
+  echo "📦 npm グローバルの更新:"
+  # 対象: 本ツールで導入する npm グローバル
+  npm_targets=("@openai/codex" "@google/gemini-cli")
+  for pkg in "${npm_targets[@]}"; do
+    if npm ls -g --depth=0 "$pkg" >/dev/null 2>&1; then
+      run_or_preview "$pkg を更新" npm update -g "$pkg"
+    else
+      echo "  ⏭️  $pkg は未インストール"
+    fi
+  done
+else
+  echo "⏭️  npm が未インストールのためスキップ"
+fi
+
+echo ""
+
+# -----------------------------------------------------------------------
+# 4. 独自インストーラ（Claude Code / GitHub Copilot CLI）
+# -----------------------------------------------------------------------
+echo "🤖 独自インストーラ系 AI CLI の更新:"
+if command -v claude &>/dev/null; then
+  run_or_preview "Claude Code" bash -c 'timeout 20 claude update </dev/null || true'
+else
+  echo "  ⏭️  claude は未インストール"
+fi
+
+if command -v copilot &>/dev/null && [[ "$(command -v copilot 2>/dev/null)" != *".vscode-server"* ]]; then
+  run_or_preview "GitHub Copilot CLI" bash -c 'timeout 20 copilot update </dev/null || true'
+else
+  echo "  ⏭️  copilot は未インストール（または VS Code shim）"
+fi
+
+echo ""
+echo "✅ ツール一括更新を完了しました"
+
+if [ -n "${LOG_FILE:-}" ]; then
+  echo "ℹ️  更新ログ: $LOG_FILE"
+fi


### PR DESCRIPTION
## Summary

- 新規スクリプト `scripts/update-tools.sh` を追加（mise / uv / npm / native installer を一括更新）
- `install.sh update` サブコマンドを追加してリモート利用（curl｜bash）でも起動可能
- `--dry-run` / `SETUP_LOG` 対応

## Update Coverage

| 経路 | 対象 |
|---|---|
| **mise** | `mise self-update` + `mise upgrade` + `mise reshim` |
| **uv tool** | `uv tool upgrade --all`（markitdown 等） |
| **npm global** | `@openai/codex` / `@google/gemini-cli` |
| **Native installer** | `claude update` / `copilot update`（タイムアウト付き） |

## Key Design

- 冪等性: 任意のツール未インストールでも失敗しない
- 安全性: 各コマンドは `|| echo "続行します"` で部分失敗を吸収、全体は中断しない
- 可観測性: `--dry-run` で事前に実行内容を確認可能
- ログ: `SETUP_LOG=1` で setup-local-ubuntu.sh と同じログ機構

## Changes

- `scripts/update-tools.sh` を新規作成（実行権限付き）
- `install.sh` に `update` サブコマンドを追加
- ついでに `install.sh` を `.editorconfig`（2-space）に合わせて整形

## Type of Change

- [x] New feature
- [x] Refactoring（install.sh の整形）

## Testing

- [x] `bash -n` syntax check passes (update-tools.sh / install.sh)
- [x] `shellcheck --severity=warning` passes
- [x] `shfmt -d` produces no diff
- [x] `bash scripts/update-tools.sh --dry-run` で期待通りの出力
- [x] `bash install.sh --help` で update コマンドが表示
- [x] lefthook pre-commit hooks pass

## Checklist

- [x] Code follows project conventions
- [x] Linters pass
- [x] Self-reviewed

Closes #19
Refs #13