### PR TITLE
feat: add non-interactive mode and BATS tests for shell config logic

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -15,3 +15,4 @@ config:
 ignores:
   - "**/node_modules"
   - "**/.claude/plans"
+  - "**/*.bats"

--- a/.mise.toml
+++ b/.mise.toml
@@ -6,6 +6,7 @@ pnpm = "10"
 # Linters & formatters
 shellcheck = "0.11"
 shfmt = "3"
+bats = "1"
 "npm:markdownlint-cli2" = "0.21"
 "pipx:yamllint" = "1"
 yamlfmt = "0.21"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,33 @@ This is a personal project maintained by [ozzy-labs](https://github.com/ozzy-lab
 
 If you find a bug or have an idea for improvement, please open an issue.
 
+## Testing
+
+### Non-interactive mode
+
+Set either environment variable to skip interactive prompts (useful in CI / Docker):
+
+```bash
+WSL_DEV_SETUP_ASSUME_YES=1 ./install.sh local    # explicit opt-in
+CI=true ./install.sh local                        # auto-enabled in most CI systems
+```
+
+Behavior:
+
+- `[Y/n]` prompts → auto `Y` (install)
+- `[y/N]` prompts (Azure CLI / Google Cloud CLI / non-Ubuntu confirmation) → auto `N` (skip / abort)
+- Git username/email: pre-configure via `git config --global user.{name,email}` beforehand to land on the "already configured" code path
+
+### Local test execution
+
+```bash
+# L0: Smoke tests (~500ms, no network)
+./tests/smoke/run.sh
+
+# L2: BATS unit tests
+mise exec -- bats tests/unit/
+```
+
 ## License
 
 By interacting with this project, you agree that any contributions you make will be licensed under the [MIT License](LICENSE).

--- a/scripts/setup-local-ubuntu.sh
+++ b/scripts/setup-local-ubuntu.sh
@@ -46,6 +46,28 @@ MISE_BIN="$HOME/.local/bin/mise"
 # ユーティリティ関数
 # ========================================
 
+# 非対話モードかどうかを判定
+# WSL_DEV_SETUP_ASSUME_YES=1 or CI=true でプロンプトを自動回答する
+_is_non_interactive() {
+  [ "${WSL_DEV_SETUP_ASSUME_YES:-0}" = "1" ] || [ "${CI:-}" = "true" ]
+}
+
+# 直前の `read -p "... [Y/n]"` に対して非対話時の既定値 Y を適用
+_apply_non_interactive_yes() {
+  if _is_non_interactive; then
+    REPLY=Y
+    echo "Y (non-interactive)"
+  fi
+}
+
+# 直前の `read -p "... [y/N]"` に対して非対話時の既定値 N を適用
+_apply_non_interactive_no() {
+  if _is_non_interactive; then
+    REPLY=N
+    echo "N (non-interactive)"
+  fi
+}
+
 # シェル設定ファイルに行を追加する関数
 add_to_shell_config() {
   local file="$1"
@@ -772,6 +794,7 @@ if ! grep -qi "ubuntu\|debian" /etc/os-release 2>/dev/null; then
   echo "⚠️  このスクリプトは Ubuntu/Debian 系ディストリビューション用です"
   echo "ℹ️  現在の OS: $(grep PRETTY_NAME /etc/os-release | cut -d'"' -f2)"
   read -p "続行しますか？ (y/N): " -n 1 -r
+  _apply_non_interactive_no
   echo
   echo "ℹ️  ユーザー入力: $REPLY" # ログに記録
   if [[ ! $REPLY =~ ^[Yy]$ ]]; then
@@ -809,6 +832,10 @@ echo "  y: すべてインストール（デフォルト）"
 echo "  n: 個別に選択"
 echo ""
 read -p "選択 [Y/n]: " -n 1 -r INSTALL_ALL
+if _is_non_interactive; then
+  INSTALL_ALL=Y
+  echo "Y (non-interactive)"
+fi
 echo ""
 echo "ℹ️  ユーザー入力: ${INSTALL_ALL:-Y}"
 
@@ -821,31 +848,37 @@ if [[ ! $INSTALL_ALL =~ ^[Yy]?$ ]]; then
 
   # 基本CLIツール
   read -p "📌 基本CLIツール (tree, fzf, jq, ripgrep, fd) をインストールしますか? [Y/n]: " -n 1 -r
+  _apply_non_interactive_yes
   echo ""
   [[ $REPLY =~ ^[Nn]$ ]] && INSTALL_BASIC_CLI=0
 
   # ビルドツール
   read -p "🔧 ビルドツール (build-essential) をインストールしますか? [Y/n]: " -n 1 -r
+  _apply_non_interactive_yes
   echo ""
   [[ $REPLY =~ ^[Nn]$ ]] && INSTALL_BUILD_TOOLS=0
 
   # Git関連ツール
   read -p "🔧 Git関連ツール (Git, GitHub CLI, gitleaks) をインストールしますか? [Y/n]: " -n 1 -r
+  _apply_non_interactive_yes
   echo ""
   [[ $REPLY =~ ^[Nn]$ ]] && INSTALL_GIT_TOOLS=0
 
   # Node.js環境
   read -p "📦 Node.js環境 (mise, Node.js, pnpm) をインストールしますか? [Y/n]: " -n 1 -r
+  _apply_non_interactive_yes
   echo ""
   [[ $REPLY =~ ^[Nn]$ ]] && INSTALL_NODE=0
 
   # Python環境
   read -p "🐍 Python環境 (mise, Python, uv) をインストールしますか? [Y/n]: " -n 1 -r
+  _apply_non_interactive_yes
   echo ""
   [[ $REPLY =~ ^[Nn]$ ]] && INSTALL_PYTHON=0
 
   # コンテナツール
   read -p "🐳 コンテナツール (Docker, Docker Compose) をインストールしますか? [Y/n]: " -n 1 -r
+  _apply_non_interactive_yes
   echo ""
   [[ $REPLY =~ ^[Nn]$ ]] && INSTALL_CONTAINER=0
 
@@ -853,14 +886,17 @@ if [[ ! $INSTALL_ALL =~ ^[Yy]?$ ]]; then
   echo ""
   echo "☁️ クラウドツール:"
   read -p "  AWS CLI をインストールしますか? [Y/n]: " -n 1 -r
+  _apply_non_interactive_yes
   echo ""
   [[ $REPLY =~ ^[Nn]$ ]] && INSTALL_AWS_CLI=0
 
   read -p "  Azure CLI をインストールしますか? [y/N]: " -n 1 -r
+  _apply_non_interactive_no
   echo ""
   [[ $REPLY =~ ^[Yy]$ ]] && INSTALL_AZURE_CLI=1
 
   read -p "  Google Cloud CLI をインストールしますか? [y/N]: " -n 1 -r
+  _apply_non_interactive_no
   echo ""
   [[ $REPLY =~ ^[Yy]$ ]] && INSTALL_GCLOUD_CLI=1
 
@@ -868,30 +904,36 @@ if [[ ! $INSTALL_ALL =~ ^[Yy]?$ ]]; then
   echo ""
   echo "🤖 AIエージェント CLI:"
   read -p "  Claude Code をインストールしますか? [Y/n]: " -n 1 -r
+  _apply_non_interactive_yes
   echo ""
   [[ $REPLY =~ ^[Nn]$ ]] && INSTALL_CLAUDE_CODE=0
 
   read -p "  Codex CLI をインストールしますか? [Y/n]: " -n 1 -r
+  _apply_non_interactive_yes
   echo ""
   [[ $REPLY =~ ^[Nn]$ ]] && INSTALL_CODEX_CLI=0
 
   read -p "  GitHub Copilot CLI をインストールしますか? [Y/n]: " -n 1 -r
+  _apply_non_interactive_yes
   echo ""
   [[ $REPLY =~ ^[Nn]$ ]] && INSTALL_COPILOT_CLI=0
 
   read -p "  Gemini CLI をインストールしますか? [Y/n]: " -n 1 -r
+  _apply_non_interactive_yes
   echo ""
   [[ $REPLY =~ ^[Nn]$ ]] && INSTALL_GEMINI_CLI=0
 
   # AIパワーツール
   echo ""
   read -p "🧠 AIパワーツール (markitdown, tesseract-ocr, ffmpeg, ast-grep, yq) をインストールしますか? [Y/n]: " -n 1 -r
+  _apply_non_interactive_yes
   echo ""
   [[ $REPLY =~ ^[Nn]$ ]] && INSTALL_AI_POWER_TOOLS=0
 
   # 開発補助ツール
   echo ""
   read -p "🛠️ 開発補助ツール (just, zoxide, shellcheck) をインストールしますか? [Y/n]: " -n 1 -r
+  _apply_non_interactive_yes
   echo ""
   [[ $REPLY =~ ^[Nn]$ ]] && INSTALL_DEV_TOOLS=0
 fi

--- a/tests/unit/shell-config.bats
+++ b/tests/unit/shell-config.bats
@@ -1,0 +1,162 @@
+#!/usr/bin/env bats
+# =======================================================================
+# tests/unit/shell-config.bats
+# -----------------------------------------------------------------------
+# setup-local-ubuntu.sh 内の add_to_shell_config 関数の冪等性・パターン
+# 検出・エッジケースを検証する。
+#
+# HOME を BATS_TEST_TMPDIR に差し替えて実ホームディレクトリを汚染しない。
+# =======================================================================
+
+setup() {
+  SCRIPT_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+  # 実ホームを汚染しないよう tmpdir を HOME として使用
+  export HOME="$BATS_TEST_TMPDIR"
+  # setup-local-ubuntu.sh の上から関数定義部分までを source してロード
+  # メイン処理（最下部の実行ブロック）を走らせないよう、関数定義セクションだけを抽出
+  _script="$SCRIPT_ROOT/scripts/setup-local-ubuntu.sh"
+  # 関数定義 & ヘルパーがある範囲を抽出（先頭から「メイン処理開始」コメントまで）
+  _extracted="$BATS_TEST_TMPDIR/functions.sh"
+  awk '/^# メイン処理開始/ {exit} {print}' "$_script" > "$_extracted"
+  # shellcheck disable=SC1090
+  source "$_extracted"
+}
+
+# ------------------------------------------------------------------
+# _is_non_interactive
+# ------------------------------------------------------------------
+
+@test "_is_non_interactive: returns true when WSL_DEV_SETUP_ASSUME_YES=1" {
+  WSL_DEV_SETUP_ASSUME_YES=1
+  unset CI
+  run _is_non_interactive
+  [ "$status" -eq 0 ]
+}
+
+@test "_is_non_interactive: returns true when CI=true" {
+  unset WSL_DEV_SETUP_ASSUME_YES
+  CI=true
+  run _is_non_interactive
+  [ "$status" -eq 0 ]
+}
+
+@test "_is_non_interactive: returns false when neither env is set" {
+  unset WSL_DEV_SETUP_ASSUME_YES CI
+  run _is_non_interactive
+  [ "$status" -ne 0 ]
+}
+
+@test "_is_non_interactive: returns false for other values" {
+  # shellcheck disable=SC2034  # 変数は sourced 関数経由で参照される
+  WSL_DEV_SETUP_ASSUME_YES=0
+  # shellcheck disable=SC2034
+  CI=false
+  run _is_non_interactive
+  [ "$status" -ne 0 ]
+}
+
+# ------------------------------------------------------------------
+# add_to_shell_config: 未存在ファイル
+# ------------------------------------------------------------------
+
+@test "add_to_shell_config: warns when target file does not exist (.bashrc)" {
+  run add_to_shell_config "$HOME/.bashrc" "PATTERN" "CONTENT" "DESC"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"見つかりません"* ]]
+  [ ! -f "$HOME/.bashrc" ]
+}
+
+@test "add_to_shell_config: zsh-specific warning mentions zsh" {
+  run add_to_shell_config "$HOME/.zshrc" "PATTERN" "CONTENT" "DESC"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"zsh を使用していない場合は問題ありません"* ]]
+}
+
+# ------------------------------------------------------------------
+# add_to_shell_config: 新規パターン追加
+# ------------------------------------------------------------------
+
+@test "add_to_shell_config: appends new content when pattern not found" {
+  touch "$HOME/.bashrc"
+  run add_to_shell_config "$HOME/.bashrc" "EXPORT_FOO" "export FOO=1" "added FOO"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"added FOO"* ]]
+  grep -q "export FOO=1" "$HOME/.bashrc"
+}
+
+@test "add_to_shell_config: preserves existing content" {
+  echo "# existing line" > "$HOME/.bashrc"
+  run add_to_shell_config "$HOME/.bashrc" "EXPORT_FOO" "export FOO=1" "added FOO"
+  [ "$status" -eq 0 ]
+  grep -q "existing line" "$HOME/.bashrc"
+  grep -q "export FOO=1" "$HOME/.bashrc"
+}
+
+# ------------------------------------------------------------------
+# add_to_shell_config: 冪等性
+# ------------------------------------------------------------------
+
+@test "add_to_shell_config: skips when pattern already present" {
+  echo "export FOO=1" > "$HOME/.bashrc"
+  run add_to_shell_config "$HOME/.bashrc" "FOO=1" "export FOO=1" "added FOO"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"既に設定済み"* ]]
+  # 行数が増えていない
+  [ "$(wc -l < "$HOME/.bashrc")" -eq 1 ]
+}
+
+@test "add_to_shell_config: running twice does not duplicate content" {
+  # 契約: pattern は追加される content 内に存在するものを指定する
+  touch "$HOME/.bashrc"
+  add_to_shell_config "$HOME/.bashrc" "export FOO=1" "export FOO=1" "added FOO" >/dev/null
+  add_to_shell_config "$HOME/.bashrc" "export FOO=1" "export FOO=1" "added FOO" >/dev/null
+  # パターン出現回数は 1 回のみ
+  [ "$(grep -c "export FOO=1" "$HOME/.bashrc")" -eq 1 ]
+}
+
+@test "add_to_shell_config: running three times still yields single occurrence" {
+  touch "$HOME/.bashrc"
+  for _i in 1 2 3; do
+    add_to_shell_config "$HOME/.bashrc" "export FOO=1" "export FOO=1" "added FOO" >/dev/null
+  done
+  [ "$(grep -c "export FOO=1" "$HOME/.bashrc")" -eq 1 ]
+}
+
+# ------------------------------------------------------------------
+# add_to_shell_config: パターンマッチ
+# ------------------------------------------------------------------
+
+@test "add_to_shell_config: pattern substring matches existing content" {
+  cat > "$HOME/.bashrc" <<'BASHRC'
+# Some shell integration
+eval "$(mise activate bash)"
+BASHRC
+  run add_to_shell_config "$HOME/.bashrc" "mise activate bash" "eval \"\$(mise activate bash)\"" "mise init"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"既に設定済み"* ]]
+}
+
+@test "add_to_shell_config: different pattern adds alongside existing" {
+  cat > "$HOME/.bashrc" <<'BASHRC'
+eval "$(mise activate bash)"
+BASHRC
+  run add_to_shell_config "$HOME/.bashrc" "zoxide init" 'eval "$(zoxide init bash)"' "zoxide init"
+  [ "$status" -eq 0 ]
+  grep -q "mise activate" "$HOME/.bashrc"
+  grep -q "zoxide init" "$HOME/.bashrc"
+}
+
+# ------------------------------------------------------------------
+# add_to_shell_config: 複数行コンテンツ
+# ------------------------------------------------------------------
+
+@test "add_to_shell_config: multi-line content is appended verbatim" {
+  touch "$HOME/.bashrc"
+  multi='# comment
+export FOO=1
+export BAR=2'
+  add_to_shell_config "$HOME/.bashrc" "FOO=1" "$multi" "multi" >/dev/null
+  grep -q "^# comment$" "$HOME/.bashrc"
+  grep -q "^export FOO=1$" "$HOME/.bashrc"
+  grep -q "^export BAR=2$" "$HOME/.bashrc"
+}


### PR DESCRIPTION
## Summary

Enables CI / Docker to drive the setup script without a TTY, and adds BATS unit tests for the most mutation-heavy helper.

## Non-interactive mode

- `_is_non_interactive` returns true when `WSL_DEV_SETUP_ASSUME_YES=1` or `CI=true`
- `_apply_non_interactive_yes` / `_no` helpers mutate `REPLY` after each `read -p` without touching the interactive UX
- `[Y/n]` prompts → auto Y; `[y/N]` prompts (Azure/GCP, non-Ubuntu confirmation) → auto N
- Git config uses existing "already configured" path via pre-set `git config --global`

## BATS tests (14, all passing)

- `_is_non_interactive` truth table (4 cases)
- `add_to_shell_config` coverage:
  - Missing file warnings (zshrc vs bashrc branching)
  - New pattern append / existing content preservation
  - Idempotency (2× and 3× runs produce single occurrence)
  - Pattern substring matching
  - Multi-line content verbatim append

`HOME` is redirected to `BATS_TEST_TMPDIR` so the host shell config is never touched.

## Docs

- CONTRIBUTING.md now documents non-interactive mode env vars and local test execution for smoke / unit suites

## Type of Change

- [x] New feature
- [x] Tests

## Testing

- [x] `mise exec -- bats tests/unit/` → 14/14 pass
- [x] `./tests/smoke/run.sh` still 11/11 pass (regression check)
- [x] `shellcheck --severity=warning` passes
- [x] `shfmt -d` produces no diff
- [x] lefthook pre-commit hooks pass

## Checklist

- [x] Code follows project conventions
- [x] Linters pass
- [x] Self-reviewed

Closes #30
Refs #28