### PR TITLE
test: add Docker-based integration tests for Ubuntu 22.04 / 24.04

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,17 @@ Behavior:
 
 # L2: BATS unit tests
 mise exec -- bats tests/unit/
+
+# L3: Docker integration tests (~5-10 min per version)
+./tests/integration/run.sh                 # default: ubuntu:24.04
+./tests/integration/run.sh 22.04 24.04     # multiple versions
+./tests/integration/run.sh devel           # canary (next Ubuntu)
 ```
+
+`tests/integration/run.sh` picks up `GITHUB_TOKEN` from either your environment
+or `gh auth token` (if `gh` is installed). Forwarding it to the container raises
+mise's GitHub API rate limit from 60 to 5000 requests/hour, which matters when
+running the full suite multiple times in short succession.
 
 ## License
 

--- a/scripts/setup-local-ubuntu.sh
+++ b/scripts/setup-local-ubuntu.sh
@@ -5,35 +5,36 @@ set -e
 # ========================================
 # グローバル変数（インストール対象フラグ）
 # ========================================
+# 環境変数で事前に設定されている場合はそれを尊重（CI / Docker でのオーバーライド用途）
 
 # 基本開発環境
-INSTALL_BUILD_TOOLS=1 # build-essential
-INSTALL_BASIC_CLI=1   # tree, fzf, jq, ripgrep, fd, unzip, wslu
-INSTALL_GIT_TOOLS=1   # Git, GitHub CLI, gitleaks
+INSTALL_BUILD_TOOLS="${INSTALL_BUILD_TOOLS:-1}" # build-essential
+INSTALL_BASIC_CLI="${INSTALL_BASIC_CLI:-1}"     # tree, fzf, jq, ripgrep, fd, unzip, wslu
+INSTALL_GIT_TOOLS="${INSTALL_GIT_TOOLS:-1}"     # Git, GitHub CLI, gitleaks
 
 # プログラミング言語環境（mise で統一管理）
-INSTALL_NODE=1   # mise + Node.js LTS + pnpm
-INSTALL_PYTHON=1 # mise + Python + uv
+INSTALL_NODE="${INSTALL_NODE:-1}"     # mise + Node.js LTS + pnpm
+INSTALL_PYTHON="${INSTALL_PYTHON:-1}" # mise + Python + uv
 
 # コンテナツール
-INSTALL_CONTAINER=1 # Docker, Docker Compose
+INSTALL_CONTAINER="${INSTALL_CONTAINER:-1}" # Docker, Docker Compose
 
 # クラウドツール（個別選択可能、Azure/GCP は opt-in）
-INSTALL_AWS_CLI=1    # AWS CLI (デフォルト ON)
-INSTALL_AZURE_CLI=0  # Azure CLI (opt-in)
-INSTALL_GCLOUD_CLI=0 # Google Cloud CLI (opt-in)
+INSTALL_AWS_CLI="${INSTALL_AWS_CLI:-1}"       # AWS CLI (デフォルト ON)
+INSTALL_AZURE_CLI="${INSTALL_AZURE_CLI:-0}"   # Azure CLI (opt-in)
+INSTALL_GCLOUD_CLI="${INSTALL_GCLOUD_CLI:-0}" # Google Cloud CLI (opt-in)
 
 # AIエージェント CLI（個別選択可能）
-INSTALL_CLAUDE_CODE=1 # Claude Code
-INSTALL_CODEX_CLI=1   # Codex CLI
-INSTALL_COPILOT_CLI=1 # GitHub Copilot CLI
-INSTALL_GEMINI_CLI=1  # Gemini CLI
+INSTALL_CLAUDE_CODE="${INSTALL_CLAUDE_CODE:-1}" # Claude Code
+INSTALL_CODEX_CLI="${INSTALL_CODEX_CLI:-1}"     # Codex CLI
+INSTALL_COPILOT_CLI="${INSTALL_COPILOT_CLI:-1}" # GitHub Copilot CLI
+INSTALL_GEMINI_CLI="${INSTALL_GEMINI_CLI:-1}"   # Gemini CLI
 
 # AIパワーツール（エージェントの文書読み込み・検索を強化）
-INSTALL_AI_POWER_TOOLS=1 # markitdown, tesseract-ocr(+jpn), ffmpeg, ast-grep, yq
+INSTALL_AI_POWER_TOOLS="${INSTALL_AI_POWER_TOOLS:-1}" # markitdown, tesseract-ocr(+jpn), ffmpeg, ast-grep, yq
 
 # 開発補助ツール
-INSTALL_DEV_TOOLS=1 # just, zoxide, shellcheck
+INSTALL_DEV_TOOLS="${INSTALL_DEV_TOOLS:-1}" # just, zoxide, shellcheck
 
 # ========================================
 # グローバル変数（実行時に設定される値）
@@ -52,20 +53,34 @@ _is_non_interactive() {
   [ "${WSL_DEV_SETUP_ASSUME_YES:-0}" = "1" ] || [ "${CI:-}" = "true" ]
 }
 
-# 直前の `read -p "... [Y/n]"` に対して非対話時の既定値 Y を適用
-_apply_non_interactive_yes() {
+# [Y/n] プロンプト（既定 Y）を処理し、REPLY に結果を設定する
+# 非対話時は read をスキップして REPLY=Y を即設定
+# $1: プロンプト文字列
+_prompt_default_yes() {
+  local prompt="$1"
   if _is_non_interactive; then
     REPLY=Y
-    echo "Y (non-interactive)"
+    printf '%sY (non-interactive)\n' "$prompt"
+    return 0
   fi
+  REPLY=""
+  read -p "$prompt" -n 1 -r || true
+  echo ""
 }
 
-# 直前の `read -p "... [y/N]"` に対して非対話時の既定値 N を適用
-_apply_non_interactive_no() {
+# [y/N] プロンプト（既定 N）を処理し、REPLY に結果を設定する
+# 非対話時は read をスキップして REPLY=N を即設定
+# $1: プロンプト文字列
+_prompt_default_no() {
+  local prompt="$1"
   if _is_non_interactive; then
     REPLY=N
-    echo "N (non-interactive)"
+    printf '%sN (non-interactive)\n' "$prompt"
+    return 0
   fi
+  REPLY=""
+  read -p "$prompt" -n 1 -r || true
+  echo ""
 }
 
 # シェル設定ファイルに行を追加する関数
@@ -322,9 +337,12 @@ ensure_mise_installed() {
   export PATH="$HOME/.local/share/mise/shims:$HOME/.local/bin:$PATH"
 
   # シェル統合（mise activate）を設定
-  add_to_shell_config ~/.zshrc 'mise activate zsh' '# mise（バージョン管理）
+  # 注意: パターンは書き込まれた文字列内に実在する部分列を使う必要がある。
+  # eval 行には `" activate zsh)"` のように途中に `"` が入るため、
+  # コメント行の固定文字列（"# mise（バージョン管理）"）をアンカーとして利用する。
+  add_to_shell_config ~/.zshrc '# mise（バージョン管理）' '# mise（バージョン管理）
 eval "$("$HOME/.local/bin/mise" activate zsh)"' "~/.zshrc に mise 初期化を追加しました"
-  add_to_shell_config ~/.bashrc 'mise activate bash' '# mise（バージョン管理）
+  add_to_shell_config ~/.bashrc '# mise（バージョン管理）' '# mise（バージョン管理）
 eval "$("$HOME/.local/bin/mise" activate bash)"' "~/.bashrc に mise 初期化を追加しました"
 
   _MISE_INITIALIZED=1
@@ -672,38 +690,17 @@ install_dev_tools() {
   echo ""
   echo "🛠️ 開発補助ツールをインストール中..."
 
-  # just のインストール・アップデート
-  if ! command -v just &>/dev/null; then
-    curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | sudo bash -s -- --to /usr/local/bin
-    echo "  ✅ just インストール完了"
-  else
-    echo "  ℹ️  just を最新版に更新中..."
-    curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | sudo bash -s -- --to /usr/local/bin --force >/dev/null 2>&1
-    echo "  ⏭️  just は最新版です"
-  fi
-
-  # zoxide のインストール・アップデート
-  if ! command -v zoxide &>/dev/null; then
-    curl -sSfL https://raw.githubusercontent.com/ajeetdsouza/zoxide/main/install.sh | sh
-    echo "  ✅ zoxide インストール完了"
-
-    # PATH を更新して zoxide を使えるようにする（インストール直後に必要）
-    # zoxide は ~/.local/bin にインストールされる
-    export PATH="$HOME/.local/bin:$PATH"
-
-    # zoxide の初期化を .bashrc と .zshrc に追加
-    add_to_shell_config ~/.bashrc "zoxide init bash" 'eval "$(zoxide init bash)"' "~/.bashrc に zoxide 初期化を追加しました"
-    add_to_shell_config ~/.zshrc "zoxide init zsh" 'eval "$(zoxide init zsh)"' "~/.zshrc に zoxide 初期化を追加しました"
-  else
-    echo "  ℹ️  zoxide を最新版に更新中..."
-    curl -sSfL https://raw.githubusercontent.com/ajeetdsouza/zoxide/main/install.sh | sh >/dev/null 2>&1
-    echo "  ⏭️  zoxide は最新版です"
-  fi
-
-  # Shellcheck（シェル静的解析）を mise 経由で導入
-  # AI エージェントが書くシェルスクリプト / 本ツール自身のシェルスクリプトの品質担保に活用
   ensure_mise_installed || return 1
+
+  # just / zoxide / shellcheck をすべて mise 経由で導入
+  # （公式インストーラは GitHub API レートリミットで詰まりやすいため mise に統一）
+  mise_use_global "just@latest" "just"
+  mise_use_global "zoxide@latest" "zoxide"
   mise_use_global "shellcheck@latest" "shellcheck"
+
+  # zoxide のシェル初期化を追加（初回のみ）
+  add_to_shell_config ~/.bashrc "zoxide init bash" 'eval "$(zoxide init bash)"' "~/.bashrc に zoxide 初期化を追加しました"
+  add_to_shell_config ~/.zshrc "zoxide init zsh" 'eval "$(zoxide init zsh)"' "~/.zshrc に zoxide 初期化を追加しました"
 
   echo "✅ 開発補助ツールインストール完了"
 }
@@ -793,8 +790,7 @@ fi
 if ! grep -qi "ubuntu\|debian" /etc/os-release 2>/dev/null; then
   echo "⚠️  このスクリプトは Ubuntu/Debian 系ディストリビューション用です"
   echo "ℹ️  現在の OS: $(grep PRETTY_NAME /etc/os-release | cut -d'"' -f2)"
-  read -p "続行しますか？ (y/N): " -n 1 -r
-  _apply_non_interactive_no
+  _prompt_default_no "続行しますか？ (y/N): "
   echo
   echo "ℹ️  ユーザー入力: $REPLY" # ログに記録
   if [[ ! $REPLY =~ ^[Yy]$ ]]; then
@@ -831,12 +827,14 @@ echo "すべてのツールをインストールしますか？"
 echo "  y: すべてインストール（デフォルト）"
 echo "  n: 個別に選択"
 echo ""
-read -p "選択 [Y/n]: " -n 1 -r INSTALL_ALL
 if _is_non_interactive; then
   INSTALL_ALL=Y
-  echo "Y (non-interactive)"
+  echo "選択 [Y/n]: Y (non-interactive)"
+else
+  INSTALL_ALL=""
+  read -p "選択 [Y/n]: " -n 1 -r INSTALL_ALL || true
+  echo ""
 fi
-echo ""
 echo "ℹ️  ユーザー入力: ${INSTALL_ALL:-Y}"
 
 if [[ ! $INSTALL_ALL =~ ^[Yy]?$ ]]; then
@@ -847,93 +845,78 @@ if [[ ! $INSTALL_ALL =~ ^[Yy]?$ ]]; then
   echo ""
 
   # 基本CLIツール
-  read -p "📌 基本CLIツール (tree, fzf, jq, ripgrep, fd) をインストールしますか? [Y/n]: " -n 1 -r
-  _apply_non_interactive_yes
+  _prompt_default_yes "📌 基本CLIツール (tree, fzf, jq, ripgrep, fd) をインストールしますか? [Y/n]: "
   echo ""
   [[ $REPLY =~ ^[Nn]$ ]] && INSTALL_BASIC_CLI=0
 
   # ビルドツール
-  read -p "🔧 ビルドツール (build-essential) をインストールしますか? [Y/n]: " -n 1 -r
-  _apply_non_interactive_yes
+  _prompt_default_yes "🔧 ビルドツール (build-essential) をインストールしますか? [Y/n]: "
   echo ""
   [[ $REPLY =~ ^[Nn]$ ]] && INSTALL_BUILD_TOOLS=0
 
   # Git関連ツール
-  read -p "🔧 Git関連ツール (Git, GitHub CLI, gitleaks) をインストールしますか? [Y/n]: " -n 1 -r
-  _apply_non_interactive_yes
+  _prompt_default_yes "🔧 Git関連ツール (Git, GitHub CLI, gitleaks) をインストールしますか? [Y/n]: "
   echo ""
   [[ $REPLY =~ ^[Nn]$ ]] && INSTALL_GIT_TOOLS=0
 
   # Node.js環境
-  read -p "📦 Node.js環境 (mise, Node.js, pnpm) をインストールしますか? [Y/n]: " -n 1 -r
-  _apply_non_interactive_yes
+  _prompt_default_yes "📦 Node.js環境 (mise, Node.js, pnpm) をインストールしますか? [Y/n]: "
   echo ""
   [[ $REPLY =~ ^[Nn]$ ]] && INSTALL_NODE=0
 
   # Python環境
-  read -p "🐍 Python環境 (mise, Python, uv) をインストールしますか? [Y/n]: " -n 1 -r
-  _apply_non_interactive_yes
+  _prompt_default_yes "🐍 Python環境 (mise, Python, uv) をインストールしますか? [Y/n]: "
   echo ""
   [[ $REPLY =~ ^[Nn]$ ]] && INSTALL_PYTHON=0
 
   # コンテナツール
-  read -p "🐳 コンテナツール (Docker, Docker Compose) をインストールしますか? [Y/n]: " -n 1 -r
-  _apply_non_interactive_yes
+  _prompt_default_yes "🐳 コンテナツール (Docker, Docker Compose) をインストールしますか? [Y/n]: "
   echo ""
   [[ $REPLY =~ ^[Nn]$ ]] && INSTALL_CONTAINER=0
 
   # クラウドツール（個別。AWS はデフォルト ON、Azure/GCP は opt-in）
   echo ""
   echo "☁️ クラウドツール:"
-  read -p "  AWS CLI をインストールしますか? [Y/n]: " -n 1 -r
-  _apply_non_interactive_yes
+  _prompt_default_yes "  AWS CLI をインストールしますか? [Y/n]: "
   echo ""
   [[ $REPLY =~ ^[Nn]$ ]] && INSTALL_AWS_CLI=0
 
-  read -p "  Azure CLI をインストールしますか? [y/N]: " -n 1 -r
-  _apply_non_interactive_no
+  _prompt_default_no "  Azure CLI をインストールしますか? [y/N]: "
   echo ""
   [[ $REPLY =~ ^[Yy]$ ]] && INSTALL_AZURE_CLI=1
 
-  read -p "  Google Cloud CLI をインストールしますか? [y/N]: " -n 1 -r
-  _apply_non_interactive_no
+  _prompt_default_no "  Google Cloud CLI をインストールしますか? [y/N]: "
   echo ""
   [[ $REPLY =~ ^[Yy]$ ]] && INSTALL_GCLOUD_CLI=1
 
   # AIエージェント CLI（個別）
   echo ""
   echo "🤖 AIエージェント CLI:"
-  read -p "  Claude Code をインストールしますか? [Y/n]: " -n 1 -r
-  _apply_non_interactive_yes
+  _prompt_default_yes "  Claude Code をインストールしますか? [Y/n]: "
   echo ""
   [[ $REPLY =~ ^[Nn]$ ]] && INSTALL_CLAUDE_CODE=0
 
-  read -p "  Codex CLI をインストールしますか? [Y/n]: " -n 1 -r
-  _apply_non_interactive_yes
+  _prompt_default_yes "  Codex CLI をインストールしますか? [Y/n]: "
   echo ""
   [[ $REPLY =~ ^[Nn]$ ]] && INSTALL_CODEX_CLI=0
 
-  read -p "  GitHub Copilot CLI をインストールしますか? [Y/n]: " -n 1 -r
-  _apply_non_interactive_yes
+  _prompt_default_yes "  GitHub Copilot CLI をインストールしますか? [Y/n]: "
   echo ""
   [[ $REPLY =~ ^[Nn]$ ]] && INSTALL_COPILOT_CLI=0
 
-  read -p "  Gemini CLI をインストールしますか? [Y/n]: " -n 1 -r
-  _apply_non_interactive_yes
+  _prompt_default_yes "  Gemini CLI をインストールしますか? [Y/n]: "
   echo ""
   [[ $REPLY =~ ^[Nn]$ ]] && INSTALL_GEMINI_CLI=0
 
   # AIパワーツール
   echo ""
-  read -p "🧠 AIパワーツール (markitdown, tesseract-ocr, ffmpeg, ast-grep, yq) をインストールしますか? [Y/n]: " -n 1 -r
-  _apply_non_interactive_yes
+  _prompt_default_yes "🧠 AIパワーツール (markitdown, tesseract-ocr, ffmpeg, ast-grep, yq) をインストールしますか? [Y/n]: "
   echo ""
   [[ $REPLY =~ ^[Nn]$ ]] && INSTALL_AI_POWER_TOOLS=0
 
   # 開発補助ツール
   echo ""
-  read -p "🛠️ 開発補助ツール (just, zoxide, shellcheck) をインストールしますか? [Y/n]: " -n 1 -r
-  _apply_non_interactive_yes
+  _prompt_default_yes "🛠️ 開発補助ツール (just, zoxide, shellcheck) をインストールしますか? [Y/n]: "
   echo ""
   [[ $REPLY =~ ^[Nn]$ ]] && INSTALL_DEV_TOOLS=0
 fi

--- a/tests/integration/Dockerfile
+++ b/tests/integration/Dockerfile
@@ -1,0 +1,51 @@
+# =======================================================================
+# tests/integration/Dockerfile
+# -----------------------------------------------------------------------
+# Ubuntu ベースイメージ上で install.sh local を非対話モードで実行し、
+# 主要ツール導入と冪等性を検証するための統合テスト環境。
+#
+# ARG UBUNTU_VERSION には "22.04" / "24.04" / "devel" / "rolling" 等を指定。
+# =======================================================================
+ARG UBUNTU_VERSION=24.04
+FROM ubuntu:${UBUNTU_VERSION}
+
+# apt インストール時の対話プロンプト（tzdata 等）を抑制
+ENV DEBIAN_FRONTEND=noninteractive \
+    TZ=Asia/Tokyo \
+    LANG=C.UTF-8 \
+    CI=true
+
+# 最小限の前提パッケージ: スクリプトが自力でインストールする前段として必要
+# git は Git 設定の事前構成のために必要（最新版は setup-local-ubuntu.sh が PPA から入れ直す）
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        sudo \
+        git \
+        locales \
+        tzdata \
+        software-properties-common \
+    && rm -rf /var/lib/apt/lists/*
+
+# 非 root のテストユーザー + passwordless sudo
+RUN useradd --create-home --shell /bin/bash testuser \
+    && echo 'testuser ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/testuser \
+    && chmod 0440 /etc/sudoers.d/testuser
+
+# リポジトリをコピー
+WORKDIR /workspace
+COPY --chown=testuser:testuser . /workspace
+
+USER testuser
+
+# Git の最低限の設定（setup-local-ubuntu.sh の Git 設定プロンプトを回避）
+RUN git config --global user.name "Test User" \
+    && git config --global user.email "test@example.com"
+
+# コンテナ内では動かせないツールを事前に除外:
+#   - Docker Engine: DinD 必要のため INSTALL_CONTAINER=0
+#   - Azure/GCP CLI: 重量級 opt-in のためデフォルト 0 のまま
+ENV INSTALL_CONTAINER=0
+
+ENTRYPOINT ["/workspace/tests/integration/entrypoint.sh"]

--- a/tests/integration/assert-tools.sh
+++ b/tests/integration/assert-tools.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# =======================================================================
+# tests/integration/assert-tools.sh
+# -----------------------------------------------------------------------
+# 主要ツールがインストール後にバージョン取得可能であることを検証。
+# mise シム経由でのみ到達可能なツールも想定し、PATH を mise activate
+# 相当で拡張してから各コマンドを呼ぶ。
+# =======================================================================
+set -u
+
+# mise activate 相当の PATH 拡張（非インタラクティブシェルでもツールを解決）
+export PATH="$HOME/.local/share/mise/shims:$HOME/.local/bin:$HOME/.local/share/pnpm:$PATH"
+
+PASS=0
+FAIL=0
+
+# $1: ツール名（表示用）, $2...: バージョン取得コマンド
+assert_tool() {
+  local name="$1"
+  shift
+  local output
+  if output=$("$@" 2>&1); then
+    printf '  ✅ %-14s %s\n' "$name:" "$(printf '%s' "$output" | head -n1)"
+    PASS=$((PASS + 1))
+  else
+    printf '  ❌ %-14s (command failed: %s)\n' "$name:" "$*"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+echo "🔧 Version manager / runtimes"
+assert_tool "mise" mise --version
+assert_tool "node" node --version
+assert_tool "pnpm" pnpm --version
+assert_tool "python3" python3 --version
+assert_tool "uv" uv --version
+
+echo ""
+echo "🔒 Git / security"
+assert_tool "git" git --version
+assert_tool "gh" gh --version
+assert_tool "gitleaks" gitleaks version
+
+echo ""
+echo "🧠 AI power tools"
+assert_tool "markitdown" markitdown --version
+assert_tool "tesseract" tesseract --version
+assert_tool "ffmpeg" ffmpeg -version
+assert_tool "ast-grep" ast-grep --version
+assert_tool "yq" yq --version
+
+echo ""
+echo "🛠️ Dev helpers"
+assert_tool "just" just --version
+assert_tool "zoxide" zoxide --version
+assert_tool "shellcheck" shellcheck --version
+
+echo ""
+echo "📌 Basic CLI"
+assert_tool "tree" tree --version
+assert_tool "fzf" fzf --version
+assert_tool "jq" jq --version
+assert_tool "rg" rg --version
+assert_tool "fd" fd --version
+
+echo ""
+TOTAL=$((PASS + FAIL))
+if [ "$FAIL" -eq 0 ]; then
+  printf '✅ All %d tool assertions passed\n' "$TOTAL"
+  exit 0
+else
+  printf '❌ %d of %d tool assertions failed\n' "$FAIL" "$TOTAL"
+  exit 1
+fi

--- a/tests/integration/entrypoint.sh
+++ b/tests/integration/entrypoint.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# =======================================================================
+# tests/integration/entrypoint.sh
+# -----------------------------------------------------------------------
+# コンテナ内で install.sh local を 2 回実行し、主要ツールの導入と
+# 冪等性を検証する。
+# =======================================================================
+set -eo pipefail
+
+RUN1_LOG="/tmp/run1.log"
+RUN2_LOG="/tmp/run2.log"
+ASSERT_SCRIPT="/workspace/tests/integration/assert-tools.sh"
+
+printf '\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n'
+printf '🔵 1st run — setup from scratch\n'
+printf '━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n'
+if ! /workspace/install.sh local 2>&1 | tee "$RUN1_LOG"; then
+  echo "❌ 1st run failed"
+  exit 1
+fi
+
+printf '\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n'
+printf '🔍 Asserting tool installations\n'
+printf '━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n'
+
+# 新しく設定された PATH / シェル統合を反映してから assert を実行
+# shellcheck disable=SC1091
+source "$HOME/.bashrc" || true
+if ! bash "$ASSERT_SCRIPT"; then
+  echo "❌ Tool assertions failed after 1st run"
+  exit 1
+fi
+
+printf '\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n'
+printf '🔵 2nd run — idempotency check\n'
+printf '━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n'
+if ! /workspace/install.sh local 2>&1 | tee "$RUN2_LOG"; then
+  echo "❌ 2nd run failed"
+  exit 1
+fi
+
+printf '\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n'
+printf '📊 Idempotency verdict\n'
+printf '━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n'
+
+# 冪等性の判定基準:
+#   1. 2 回目実行が正常終了している（ここまで到達した時点で set -e により保証）
+#   2. ~/.bashrc 内のシェル設定行が重複していない（add_to_shell_config の冪等性）
+#   3. 2 回目は「すでに導入済み」マーカー (⏭️) が少なくとも 1 件以上出ている
+#      （完全に再インストールしているわけではないことを示す）
+RUN2_INSTALL_COUNT=$(grep -c 'インストール完了' "$RUN2_LOG" || true)
+RUN2_SKIP_COUNT=$(grep -c '⏭️' "$RUN2_LOG" || true)
+
+printf '2nd run "インストール完了" markers: %s\n' "$RUN2_INSTALL_COUNT"
+printf '2nd run "⏭️" markers:              %s\n' "$RUN2_SKIP_COUNT"
+
+if [ "$RUN2_SKIP_COUNT" -lt 5 ]; then
+  echo "❌ Expected many '⏭️' markers on 2nd run but saw only $RUN2_SKIP_COUNT"
+  echo "   (scripts should mostly skip already-installed tools)"
+  exit 1
+fi
+
+# シェル設定の重複チェック（唯一のアンカー行だけを見る）
+# PNPM_HOME ブロックは `export PNPM_HOME=` と `export PATH="$PNPM_HOME:..."` の 2 行を
+# 含むため、単純な "PNPM_HOME" カウントでは 2 回マッチしてしまう。
+# add_to_shell_config は冒頭コメント行（"# ..."）を一意なアンカーとして挿入するため、
+# そのコメント行の出現回数をチェックするのが最も堅牢。
+for anchor in \
+  "# mise（バージョン管理）" \
+  "# pnpm グローバルパッケージ" \
+  "# ローカルユーザー向けバイナリ" \
+  "# WSL2 でブラウザを開くための設定" \
+  'eval "$(zoxide init bash)"'; do
+  count=$(grep -cF "$anchor" "$HOME/.bashrc" || true)
+  if [ "$count" -gt 1 ]; then
+    echo "❌ Shell config duplication: '$anchor' appears $count times in ~/.bashrc"
+    exit 1
+  fi
+done
+
+printf '\n✅ Integration test passed (both runs completed, no shell config duplication)\n'

--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# =======================================================================
+# tests/integration/run.sh
+# -----------------------------------------------------------------------
+# ローカルで Docker 統合テストを走らせるハーネス。
+#
+# Usage:
+#   ./tests/integration/run.sh                 # デフォルト (24.04)
+#   ./tests/integration/run.sh 22.04           # 単一バージョン
+#   ./tests/integration/run.sh 22.04 24.04     # 複数バージョン逐次
+#   ./tests/integration/run.sh devel           # Canary（次期 Ubuntu）
+# =======================================================================
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "⚠️  docker コマンドが見つかりません"
+  exit 1
+fi
+
+# mise が GitHub API をレートリミット無しで叩けるよう、利用可能ならトークンを渡す
+# 優先順位: GITHUB_TOKEN env > gh CLI のトークン
+DOCKER_ENV_ARGS=()
+TOKEN_SOURCE=""
+if [ -n "${GITHUB_TOKEN:-}" ]; then
+  DOCKER_ENV_ARGS+=(-e "GITHUB_TOKEN=${GITHUB_TOKEN}")
+  TOKEN_SOURCE="env"
+elif command -v gh >/dev/null 2>&1; then
+  if _token=$(gh auth token 2>/dev/null); then
+    DOCKER_ENV_ARGS+=(-e "GITHUB_TOKEN=${_token}")
+    TOKEN_SOURCE="gh"
+  fi
+fi
+if [ -n "$TOKEN_SOURCE" ]; then
+  echo "ℹ️  GITHUB_TOKEN を container に渡します (source: $TOKEN_SOURCE)"
+fi
+
+VERSIONS=("$@")
+if [ "${#VERSIONS[@]}" -eq 0 ]; then
+  VERSIONS=("24.04")
+fi
+
+FAILED_VERSIONS=()
+
+for version in "${VERSIONS[@]}"; do
+  printf '\n═══════════════════════════════════════════\n'
+  printf '🐳 Testing against ubuntu:%s\n' "$version"
+  printf '═══════════════════════════════════════════\n'
+
+  tag="wsl-dev-setup-test:${version//[^A-Za-z0-9._-]/-}"
+
+  if ! docker build \
+    --build-arg "UBUNTU_VERSION=${version}" \
+    -t "$tag" \
+    -f "$SCRIPT_DIR/Dockerfile" \
+    "$REPO_ROOT"; then
+    echo "❌ docker build failed for ubuntu:${version}"
+    FAILED_VERSIONS+=("$version")
+    continue
+  fi
+
+  if ! docker run --rm "${DOCKER_ENV_ARGS[@]}" "$tag"; then
+    echo "❌ docker run failed for ubuntu:${version}"
+    FAILED_VERSIONS+=("$version")
+    continue
+  fi
+
+  printf '\n✅ ubuntu:%s passed\n' "$version"
+done
+
+printf '\n═══════════════════════════════════════════\n'
+if [ "${#FAILED_VERSIONS[@]}" -eq 0 ]; then
+  printf '✅ All %d version(s) passed\n' "${#VERSIONS[@]}"
+  exit 0
+else
+  printf '❌ %d version(s) failed: %s\n' "${#FAILED_VERSIONS[@]}" "${FAILED_VERSIONS[*]}"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

End-to-end integration tests that run `install.sh local` inside a clean Ubuntu container and validate idempotency on re-run.

## What's tested

- Full `install.sh local` completes non-interactively (`CI=true` env)
- All mise / apt / uv tool / npm CLIs become callable after install
- Running the script a second time:
  - Produces plenty of `⏭️` skip markers
  - Doesn't duplicate any shell config anchor in `~/.bashrc`

## Script robustness improvements surfaced by testing

- All `INSTALL_*` globals now honor environment variables (previously hard-assigned)
- Interactive prompts refactored into `_prompt_default_yes/_no` helpers that skip `read` entirely under `CI=true`, avoiding `set -e` abort on closed stdin
- `just` and `zoxide` moved to mise (their upstream installers rely on unauthenticated GitHub API which breaks under rate limit)
- mise shell-integration `add_to_shell_config` pattern fixed: the eval line contains quoted segments so `mise activate bash` was not actually present as a substring

## Local execution

```bash
./tests/integration/run.sh                 # ubuntu:24.04 default
./tests/integration/run.sh 22.04 24.04     # multiple versions
./tests/integration/run.sh devel           # canary (next Ubuntu)
```

The harness picks up `GITHUB_TOKEN` from env or `gh auth token` and forwards it to the container so mise's GitHub API calls stay within the authenticated rate limit.

## Type of Change

- [x] Tests
- [x] Refactoring (setup script becomes genuinely non-interactive-capable + more robust)

## Testing

- [x] `./tests/integration/run.sh 24.04` passes locally (~5 min)
- [x] Both install runs complete without errors
- [x] No shell config duplication in `~/.bashrc` after 2nd run
- [x] `bash -n`, shellcheck, shfmt all clean
- [x] `./tests/smoke/run.sh` still passes
- [x] `mise exec -- bats tests/unit/` still passes (14/14)
- [x] lefthook pre-commit hooks pass

## Checklist

- [x] Code follows project conventions
- [x] Linters pass
- [x] Self-reviewed

Closes #31
Refs #28