### PR TITLE
ci: add weekly canary workflow against ubuntu:devel and rolling

### DIFF
--- a/.github/workflows/canary.yaml
+++ b/.github/workflows/canary.yaml
@@ -1,0 +1,89 @@
+name: canary
+
+on:
+  schedule:
+    - cron: "0 3 * * 1" # 毎週月曜 03:00 UTC に実行
+  workflow_dispatch: # 手動実行も可能
+
+concurrency:
+  group: canary-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  issues: write # 失敗時の Issue 自動起票に必須
+
+jobs:
+  canary:
+    name: Canary (ubuntu:${{ matrix.ubuntu-tag }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        # 次期 Ubuntu リリース候補を先回り検証
+        ubuntu-tag: ["devel", "rolling"]
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+
+      - name: Build canary image (ubuntu:${{ matrix.ubuntu-tag }})
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        with:
+          context: .
+          file: tests/integration/Dockerfile
+          build-args: |
+            UBUNTU_VERSION=${{ matrix.ubuntu-tag }}
+          tags: wsl-dev-setup-canary:${{ matrix.ubuntu-tag }}
+          load: true
+          cache-from: type=gha,scope=canary-${{ matrix.ubuntu-tag }}
+          cache-to: type=gha,scope=canary-${{ matrix.ubuntu-tag }},mode=max
+
+      - name: Run integration on ubuntu:${{ matrix.ubuntu-tag }}
+        env:
+          GITHUB_TOKEN_FOR_MISE: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          docker run --rm -e "GITHUB_TOKEN=$GITHUB_TOKEN_FOR_MISE" \
+            wsl-dev-setup-canary:${{ matrix.ubuntu-tag }}
+
+      - name: Open issue on failure
+        if: failure()
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            const tag = "${{ matrix.ubuntu-tag }}";
+            const date = new Date().toISOString().slice(0, 10);
+            const { serverUrl, repo: { owner, repo }, runId } = context;
+            const runUrl = `${serverUrl}/${owner}/${repo}/actions/runs/${runId}`;
+            const title = `Canary failure: ubuntu:${tag} / ${date}`;
+            const body = [
+              `Canary workflow failed on \`ubuntu:${tag}\` on ${date}.`,
+              ``,
+              `**Run:** ${runUrl}`,
+              ``,
+              `## Triage checklist`,
+              ``,
+              `- [ ] apt package renamed / removed (e.g. \`tesseract-ocr-jpn\`, \`ffmpeg\`)`,
+              `- [ ] PPA no longer supports this Ubuntu version (e.g. \`ppa:git-core/ppa\`)`,
+              `- [ ] Upstream tool breaking change (\`mise\`, \`gitleaks\`, \`ast-grep\`, etc.)`,
+              `- [ ] Installer script behavior change (\`mise.run\`, \`astral.sh/uv\`, \`get.volta.sh\`)`,
+              `- [ ] Transient network issue — re-run \`gh workflow run canary.yaml\` to confirm`,
+              ``,
+              `## How to reproduce locally`,
+              ``,
+              `\`\`\`bash`,
+              `./tests/integration/run.sh ${tag}`,
+              `\`\`\``,
+              ``,
+              `Non-blocking: Canary failures do not gate main-line PRs.`,
+            ].join("\n");
+
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title,
+              body,
+              labels: ["canary", "investigation-needed"],
+            });

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,8 +51,21 @@ running the full suite multiple times in short succession.
 | `test-smoke.yaml` | PR + main push | Runs `tests/smoke/run.sh` (no Docker) |
 | `test-unit.yaml` | PR + main push | Runs BATS suite via `mise` |
 | `test-integration.yaml` | main push, manual, or PR labeled `ci:integration` | Runs `tests/integration/run.sh` against 22.04 + 24.04 in matrix |
+| `canary.yaml` | Weekly (Mon 03:00 UTC) + manual | Runs the integration harness against `ubuntu:devel` / `ubuntu:rolling`; opens an issue on failure |
 
 Integration tests are opt-in for PRs (~5 min/version) to keep feedback fast on code-only changes. Add the `ci:integration` label when changing `scripts/setup-local-ubuntu.sh` or `tests/integration/`.
+
+### Canary triage
+
+When the Canary workflow fails it auto-creates an issue tagged `canary` + `investigation-needed`. The issue body contains the run URL and a triage checklist:
+
+1. **apt package renamed / removed** — next Ubuntu may have dropped or renamed a package (e.g. `tesseract-ocr-jpn`)
+2. **PPA no longer supports this Ubuntu version** — `ppa:git-core/ppa` for instance is added conditionally
+3. **Upstream tool breaking change** — mise / gitleaks / ast-grep etc. may have bumped major
+4. **Installer script behavior change** — `mise.run` / `astral.sh/uv` etc. may have changed flags
+5. **Transient network issue** — re-run `gh workflow run canary.yaml`; if it passes, close as "transient"
+
+Canary failures are non-blocking by design: they surface upstream change early so we can fix it before the next Ubuntu release lands.
 
 ### WSL2 pre-release smoke checklist
 


### PR DESCRIPTION
## Summary

Auto-detect upstream breakage before it reaches stable Ubuntu releases.

## Design

- **Matrix**: `ubuntu:devel` + `ubuntu:rolling` in parallel, `fail-fast: false`
- **Runtime**: weekly (Mon 03:00 UTC) + `workflow_dispatch` for on-demand runs
- **Isolation**: `timeout-minutes: 30`, concurrency-group per ref
- **Permissions**: `issues: write` granted explicitly for the auto-issue step
- **Reuse**: shares `tests/integration/Dockerfile` with Phase 3 integration — only the `UBUNTU_VERSION` build-arg differs

## Failure handling

On failure, an issue is auto-created with:

- Title: `Canary failure: ubuntu:<tag> / <YYYY-MM-DD>` (date-stamped for history)
- Labels: `canary` + `investigation-needed`
- Body: run URL + triage checklist + local-repro command

Non-blocking: canary failures do not gate main-line PRs. They surface upstream change early so we can fix it before the next LTS ships.

## CONTRIBUTING additions

- Workflow added to the CI table
- New "Canary triage" section with the five typical failure classes and how to distinguish transient from real

## Label setup

Added three repo labels used by CI:

- `canary` — Canary workflow (upstream early-warning)
- `investigation-needed` — Needs investigation / triage
- `ci:integration` — Run the Docker integration workflow on this PR

## Type of Change

- [x] CI/CD
- [x] Documentation

## Testing

- [x] `actionlint` passes
- [x] `yamllint` passes
- [x] `markdownlint` passes
- Workflow itself will be validated after merge via manual dispatch

## Checklist

- [x] Code follows project conventions
- [x] Linters pass
- [x] Self-reviewed

Closes #33
Closes #28