### PR TITLE
chore: .claude/*.lock を gitignore に追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@ build/
 
 # Logs
 *.log
+
+# Claude Code ランタイム成果物（ScheduleWakeup などが生成するロック等）
+.claude/scheduled_tasks.lock
+.claude/*.lock


### PR DESCRIPTION
## 概要

`.claude/scheduled_tasks.lock` は Claude Code の `ScheduleWakeup` 等が生成するランタイムロックファイルで、sessionId / pid / 取得時刻を含むため共有すべきでない。`git status` のノイズを減らし、誤って `git add .` で混入するリスクを防ぐため `.gitignore` に追加する。

## 内容

```json
{"sessionId":"...","pid":...,"acquiredAt":...}
```

`.claude/*.lock` パターンで将来的に他のロックファイルが追加されても無視されるようにする。

## 変更

- `.gitignore`: `.claude/*.lock` を追加

## Testing

- [x] `git check-ignore .claude/scheduled_tasks.lock` が無視対象を確認
- [x] `git status` からロックファイルが消える
- [x] lefthook pre-commit / commitlint を通過（日本語コミットメッセージ）

## Checklist

- [x] プロジェクト規約に準拠
- [x] Linter がパス
- [x] セルフレビュー済み