### PR TITLE
test: 22.04 統合テストを修正し L1 のローカル実行手順を追記

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,14 @@ CI=true ./install.sh local                        # ほとんどの CI で自動
 # L0: Smoke tests（約 500ms、ネットワーク不要）
 ./tests/smoke/run.sh
 
+# L1: Static analysis（通常は lefthook が commit 時に自動実行）
+mise exec -- shellcheck --severity=warning install.sh scripts/*.sh tests/smoke/run.sh tests/integration/*.sh
+mise exec -- shfmt -d install.sh scripts/*.sh tests/smoke/run.sh tests/integration/*.sh
+mise exec -- markdownlint-cli2 '**/*.md'
+mise exec -- yamllint -c .yamllint.yaml .github/workflows .mise.toml .yamllint.yaml lefthook.yaml lefthook-base.yaml .markdownlint-cli2.yaml
+mise exec -- actionlint .github/workflows/*.yaml
+mise exec -- gitleaks detect --no-banner --redact -v
+
 # L2: BATS ユニットテスト
 mise exec -- bats tests/unit/
 

--- a/tests/integration/Dockerfile
+++ b/tests/integration/Dockerfile
@@ -16,13 +16,16 @@ ENV DEBIAN_FRONTEND=noninteractive \
     CI=true
 
 # 最小限の前提パッケージ: スクリプトが自力でインストールする前段として必要
-# git は Git 設定の事前構成のために必要（最新版は setup-local-ubuntu.sh が PPA から入れ直す）
+# - git: Git 設定の事前構成のため（最新版は setup-local-ubuntu.sh が PPA から入れ直す）
+# - gnupg: add-apt-repository が PPA の GPG 鍵をインポートする際に gpg-agent を必要とする。
+#   ubuntu:22.04 の minimal イメージには未同梱のため明示的に追加する。
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         ca-certificates \
         curl \
         sudo \
         git \
+        gnupg \
         locales \
         tzdata \
         software-properties-common \


### PR DESCRIPTION
## 概要

2 件の小さな修正をまとめた PR。

1. **22.04 統合テスト CI の緑化** — Docker base image への `gnupg` 追加
2. **`CONTRIBUTING.md` に L1 静的解析のローカル実行手順を追記**

本 PR は統合テスト改修（ci:integration ラベル対象）のため、PR CI でも統合テストを走らせて検証する。

## 1. 22.04 統合テスト CI の緑化

### 問題

main push 後の `test-integration` で `ubuntu:22.04` matrix のみ失敗していた：

```
gpg: error running '/usr/bin/gpg-agent': probably not installed
subprocess.CalledProcessError: Command '['gpg', ...]' returned non-zero exit status 2.
```

### 原因

`ubuntu:22.04` の minimal Docker イメージには `gpg-agent` が未同梱。`add-apt-repository ppa:git-core/ppa` が GPG 鍵インポートで必要とするため失敗。`ubuntu:24.04` ではプリインストールされているため通っていた。

### 修正

`tests/integration/Dockerfile` のプリインストール一覧に `gnupg` を追加。既存 `software-properties-common` と同じ apt レイヤーで解決できる。

これは**テスト環境のみの修正**で、本番スクリプトには無影響（実 WSL2/Ubuntu 22.04 では `gnupg` が標準で入っているため）。

### 検証

```bash
$ ./tests/integration/run.sh 22.04
...
✅ Integration test passed (both runs completed, no shell config duplication)
✅ ubuntu:22.04 passed
═══════════════════════════════════════════
✅ All 1 version(s) passed
```

ローカルで 22.04 Docker 統合テストが 2 ラン（冪等性確認含む）完走することを確認済み。

## 2. L1 静的解析のローカル実行手順

`CONTRIBUTING.md` の Testing セクションに L0 / L2 / L3 はあったが L1（静的解析）が欠けていた。lefthook が commit 時に自動実行するが、手動で走らせたいケースも多いため明文化。

対象コマンド:

- `shellcheck --severity=warning`
- `shfmt -d`
- `markdownlint-cli2`
- `yamllint`
- `actionlint`
- `gitleaks detect`

CI の `lint.yaml` と同等のチェックをローカルで再現できる。

## Type of Change

- [x] Tests
- [x] Documentation

## Testing

- [x] `./tests/integration/run.sh 22.04` がローカルで完走
- [x] `markdownlint-cli2 CONTRIBUTING.md` パス
- [x] `shellcheck` / `shfmt` / `bats` すべて緑
- [x] `./tests/smoke/run.sh` が引き続き 11/11 パス
- [x] lefthook pre-commit フックがパス
- [ ] CI の `test-integration` が 22.04 + 24.04 両方で緑になる（本 PR で検証）

## Checklist

- [x] プロジェクト規約に準拠
- [x] Linter がパス
- [x] セルフレビュー済み