### PR TITLE
fix: wslu が Ubuntu 26.04 で見つからない問題にフォールバック実装

### DIFF
--- a/scripts/setup-local-ubuntu.sh
+++ b/scripts/setup-local-ubuntu.sh
@@ -248,11 +248,36 @@ install_basic_cli_tools() {
   fi
 
   # wslu のインストール（WSL2 でブラウザを開くために必要）
+  # Ubuntu 22.04 / 24.04 は main リポジトリに含まれるが、26.04 以降は未収録の
+  # 場合があるため PPA フォールバックを用意し、いずれも失敗した場合は警告の上で
+  # セットアップ全体を中断しない（wslview なしでもホスト開発自体は機能するため）。
+  install_wslu() {
+    if sudo apt-get install -y wslu 2>/dev/null; then
+      echo "  ✅ wslu インストール完了（apt）"
+      return 0
+    fi
+    echo "  ℹ️  wslu が標準リポジトリに無いため PPA（ppa:wslutilities/wslu）を試行..."
+    if sudo add-apt-repository -y ppa:wslutilities/wslu >/dev/null 2>&1; then
+      if sudo apt-get update -qq 2>/dev/null && sudo apt-get install -y wslu 2>/dev/null; then
+        echo "  ✅ wslu インストール完了（PPA）"
+        return 0
+      fi
+      # PPA 追加には成功したが install で失敗した場合、Release ファイル欠落等で
+      # 以降の apt-get update を汚染するため PPA sources を確実に削除する
+      sudo rm -f /etc/apt/sources.list.d/wslutilities-ubuntu-wslu-*.list \
+        /etc/apt/sources.list.d/wslutilities-ubuntu-wslu-*.sources 2>/dev/null || true
+      sudo apt-get update -qq >/dev/null 2>&1 || true
+    fi
+    echo "  ⚠️  wslu のインストールに失敗しました（Ubuntu バージョン未対応の可能性）"
+    echo "  ℹ️  影響: wslview コマンドが使えないため WSL2 から Windows ブラウザの自動起動はできません"
+    echo "  ℹ️  手動インストール: https://github.com/wslutilities/wslu#installation"
+    return 0
+  }
+
   if ! command -v wslview &>/dev/null; then
-    sudo apt-get install -y wslu
-    echo "  ✅ wslu インストール完了"
+    install_wslu
   else
-    sudo apt-get install -y --only-upgrade wslu >/dev/null 2>&1
+    sudo apt-get install -y --only-upgrade wslu >/dev/null 2>&1 || true
     echo "  ⏭️  wslu は最新版です"
   fi
 


### PR DESCRIPTION
## 概要

Canary workflow（Issue #39）が ubuntu:devel（= **次期 LTS 26.04 Resolute Raccoon**）で検知した、`wslu` パッケージが apt リポジトリから見つからない問題を解消する。

## 原因

`ubuntu:26.04` の main / universe に `wslu` が未収録のため `sudo apt-get install -y wslu` が `E: Unable to locate package wslu` で失敗。`setup-local-ubuntu.sh` が `set -e` で全体中断していた。

**2026 年 4 月リリースの次期 LTS** が目前のため、この対応無しでは WSL2 ユーザーが LTS 切替直後に本ツールを使えなくなる。

## 修正内容

`install_basic_cli_tools` 内の wslu 導入部を 3 段フォールバックに変更：

```
1. apt-get install wslu          （22.04 / 24.04 で成功）
   ↓ 失敗
2. ppa:wslutilities/wslu を追加して再試行
   ↓ 失敗
3. 警告メッセージを出して続行（wslview は手動インストールへ誘導）
```

PPA 追加は成功するが `Release` ファイル欠落等で install に失敗するケース（まさに 26.04 の現状）では、以降の `apt-get update` を汚染するため **PPA sources を確実に削除するクリーンアップ**も含める。

## 設計判断

- **abort ではなく continue**: wslview が使えなくてもホスト開発自体は成立するため、セットアップ全体を止めるのは過剰
- **明示的な警告**: 手動インストールリンクも提示してユーザーが後追い対応できるようにする
- **PPA クリーンアップ**: 失敗時の副作用を次セクションに持ち越さない

## Type of Change

- [x] Bug fix（Canary で検知した上流変更への対応）

## Testing

- [x] `./tests/integration/run.sh devel`（= 26.04 Resolute Raccoon）が**2 ラン完走**
- [x] `./tests/integration/run.sh 22.04 24.04` が引き続き緑（apt 直接成功パス）
- [x] `shellcheck --severity=warning` / `shfmt -d` パス
- [x] lefthook pre-commit フックがパス
- [x] `./tests/smoke/run.sh` が引き続き 11/11 パス
- [x] `mise exec -- bats tests/unit/` が 14/14 パス

## Checklist

- [x] プロジェクト規約に準拠
- [x] Linter がパス
- [x] セルフレビュー済み

Closes #39