### PR TITLE
ci: ワークフロー使用 actions を Node.js 24 対応版へ更新

### DIFF
--- a/.github/workflows/canary.yaml
+++ b/.github/workflows/canary.yaml
@@ -24,13 +24,13 @@ jobs:
         # 次期 Ubuntu リリース候補を先回り検証
         ubuntu-tag: ["devel", "rolling"]
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Build canary image (ubuntu:${{ matrix.ubuntu-tag }})
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
           file: tests/integration/Dockerfile
@@ -50,7 +50,7 @@ jobs:
 
       - name: Open issue on failure
         if: failure()
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const tag = "${{ matrix.ubuntu-tag }}";

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -18,10 +18,10 @@ jobs:
     name: Static analysis (shellcheck / shfmt / markdownlint / yaml / gitleaks)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up mise
-        uses: jdx/mise-action@5cb1df66ed5e1fb3c670ea0b62fd17a76979826a # v2.4.3
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           cache: true
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check PR title format
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const title = context.payload.pull_request.title;
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check branch name format
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const branch = context.payload.pull_request.head.ref;

--- a/.github/workflows/test-integration.yaml
+++ b/.github/workflows/test-integration.yaml
@@ -29,13 +29,13 @@ jobs:
       matrix:
         ubuntu: ["22.04", "24.04"]
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
       - name: Build test image (ubuntu:${{ matrix.ubuntu }})
-        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
           file: tests/integration/Dockerfile

--- a/.github/workflows/test-smoke.yaml
+++ b/.github/workflows/test-smoke.yaml
@@ -19,6 +19,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Run smoke tests
         run: ./tests/smoke/run.sh

--- a/.github/workflows/test-unit.yaml
+++ b/.github/workflows/test-unit.yaml
@@ -19,10 +19,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up mise (provides bats + linters)
-        uses: jdx/mise-action@5cb1df66ed5e1fb3c670ea0b62fd17a76979826a # v2.4.3
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
           cache: true
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## 概要

GitHub Actions runner の Node.js 24 強制切替に備えて、全ワークフローが使う 5 つの actions を Node.js 24 対応のメジャーバージョンへ更新する。

## 背景

GitHub からの deprecation 通知：

> Node.js 20 actions are deprecated. Actions will be forced to run with Node.js 24 by default starting **June 2nd, 2026**. Node.js 20 will be removed from the runner on **September 16th, 2026**.

現状のままでは：

- 〜2026-06-02: CI ログに deprecation warning が出続ける
- 〜2026-09-16: Node 20 actions が動かなくなる（CI が完全に壊れる）

## 変更

全て SHA 固定のまま、Node 24 対応のメジャーへ更新：

| Action | Before | After |
|---|---|---|
| `actions/checkout` | v4.2.2 | **v6.0.2** |
| `jdx/mise-action` | v2.4.3 | **v4.0.1** |
| `docker/setup-buildx-action` | v3.11.1 | **v4.0.0** |
| `docker/build-push-action` | v6.18.0 | **v7.1.0** |
| `actions/github-script` | v8.0.0 | **v9.0.0** |

影響ファイル:

- `.github/workflows/lint.yaml`
- `.github/workflows/test-smoke.yaml`
- `.github/workflows/test-unit.yaml`
- `.github/workflows/test-integration.yaml`
- `.github/workflows/canary.yaml`
- `.github/workflows/pr-check.yaml`

## Type of Change

- [x] CI/CD（依存関係追従）

## Testing

- [x] `yamllint -c .yamllint.yaml .github/workflows/*.yaml` パス
- [x] `actionlint` パス
- [ ] PR CI でデプリケーション警告が消えることを確認（本 PR の実行で検証）
- [ ] 全ワークフロー（lint / test-smoke / test-unit / test-integration / pr-check）が緑

## Checklist

- [x] プロジェクト規約に準拠
- [x] Linter がパス
- [x] セルフレビュー済み