### PR TITLE
ci: canary の重複起票防止と ci:integration ラベル自動付与を導入

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,13 @@
+# actions/labeler の設定ファイル。
+# 変更されたファイルに応じて PR にラベルを自動付与する。
+# ドキュメント: https://github.com/actions/labeler
+
+"ci:integration":
+  - changed-files:
+      - any-glob-to-any-file:
+          - install.sh
+          - scripts/setup-local-ubuntu.sh
+          - tests/integration/**
+          - tests/smoke/**
+          - .github/workflows/test-integration.yaml
+          - .github/workflows/canary.yaml

--- a/.github/workflows/canary.yaml
+++ b/.github/workflows/canary.yaml
@@ -80,10 +80,32 @@ jobs:
               `Non-blocking: Canary failures do not gate main-line PRs.`,
             ].join("\n");
 
-            await github.rest.issues.create({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              title,
-              body,
-              labels: ["canary", "investigation-needed"],
-            });
+            // 同じ (tag, date) の Open Issue が既にあれば新規起票せずコメントで再発を記録
+            const existing = await github.paginate(
+              github.rest.issues.listForRepo,
+              {
+                owner,
+                repo,
+                state: "open",
+                labels: "canary",
+                per_page: 100,
+              },
+            );
+            const duplicate = existing.find((issue) => issue.title === title);
+
+            if (duplicate) {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: duplicate.number,
+                body: `同じ組み合わせで再発しました。\n\n**Run:** ${runUrl}`,
+              });
+            } else {
+              await github.rest.issues.create({
+                owner,
+                repo,
+                title,
+                body,
+                labels: ["canary", "investigation-needed"],
+              });
+            }

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -1,0 +1,25 @@
+name: labeler
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label:
+    name: PR 自動ラベリング
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - uses: actions/labeler@634933edcd8ababfe52f92936142cc22ac488b1b # v6.0.1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          configuration-path: .github/labeler.yml
+          sync-labels: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,6 +64,8 @@ mise exec -- bats tests/unit/
 
 統合テストは PR では opt-in（1 バージョン約 5 分）で、コード変更のみの PR のフィードバックを高速に保ちます。統合テストが必要な範囲を変更する PR には `labeler.yaml` が自動で `ci:integration` ラベルを付与するため、通常は手動付与不要です。自動判定外のケースで必要な場合は手動付与も可能です。
 
+> **注意（GITHUB_TOKEN 起点のラベル付与制約）**: PR 初回 open 時に `labeler.yaml` が付けた `ci:integration` ラベルは、同時に走る `test-integration.yaml` の label チェックには間に合わないため、**初回のみ統合テストは skip**される。2 回目以降の push（`pull_request/synchronize`）では正常に発火する。初回から統合テストを走らせたい場合は、空コミット（`git commit --allow-empty`）で再 push するか、`gh workflow run test-integration.yaml --ref <branch>` で手動 dispatch する。
+
 ### Canary トリアージ
 
 Canary ワークフローが失敗すると、`canary` + `investigation-needed` ラベル付きの Issue が自動起票されます。Issue 本文には run URL とトリアージチェックリストが含まれます：

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,9 +59,10 @@ mise exec -- bats tests/unit/
 | `test-smoke.yaml` | PR + main push | `tests/smoke/run.sh` を実行（Docker 不要） |
 | `test-unit.yaml` | PR + main push | `mise` 経由で BATS スイートを実行 |
 | `test-integration.yaml` | main push / 手動 / `ci:integration` ラベル付き PR | 22.04 + 24.04 matrix で `tests/integration/run.sh` を実行 |
-| `canary.yaml` | 週次（月曜 03:00 UTC）+ 手動 | `ubuntu:devel` / `ubuntu:rolling` で統合 harness を実行し、失敗時に Issue 自動起票 |
+| `canary.yaml` | 週次（月曜 03:00 UTC）+ 手動 | `ubuntu:devel` / `ubuntu:rolling` で統合 harness を実行し、失敗時に Issue 自動起票／既存 Open Issue があればコメントで再発を記録 |
+| `labeler.yaml` | PR (opened/synchronize/reopened) | `install.sh` / `scripts/setup-local-ubuntu.sh` / `tests/integration/**` / `tests/smoke/**` / 主要 CI を変更した PR に `ci:integration` ラベルを自動付与 |
 
-統合テストは PR では opt-in（1 バージョン約 5 分）で、コード変更のみの PR のフィードバックを高速に保ちます。`scripts/setup-local-ubuntu.sh` や `tests/integration/` を変更する PR では `ci:integration` ラベルを付与してください。
+統合テストは PR では opt-in（1 バージョン約 5 分）で、コード変更のみの PR のフィードバックを高速に保ちます。統合テストが必要な範囲を変更する PR には `labeler.yaml` が自動で `ci:integration` ラベルを付与するため、通常は手動付与不要です。自動判定外のケースで必要な場合は手動付与も可能です。
 
 ### Canary トリアージ
 


### PR DESCRIPTION
## 概要

運用上の小さな改善 2 件をまとめた PR:

1. **A1. canary ワークフローの重複 Issue 起票防止**
2. **A2. `ci:integration` ラベルの自動付与**

## A1. canary 重複起票防止

### 問題

`canary.yaml` は失敗時に日付を含めたタイトル（`Canary failure: ubuntu:<tag> / <date>`）で Issue を自動起票する。しかし同日に複数回失敗した場合、**同じタイトルの Issue が複数作成**される設計になっていた（実例: #39 と #42 の重複）。

### 修正

Issue 起票前に Open Issue 一覧をチェックし、同タイトルの Issue が既にあれば新規起票せず**既存 Issue にコメントで再発を記録**する方式に変更。

```js
const existing = await github.paginate(...);
const duplicate = existing.find(i => i.title === title);

if (duplicate) {
  await github.rest.issues.createComment({ ... });
} else {
  await github.rest.issues.create({ ... });
}
```

**副次効果**: 日跨ぎで発生した新規失敗は従来通り新しい Issue として起票されるため、履歴性も維持。

## A2. ci:integration 自動ラベル

### 問題

統合テストは PR では opt-in（`ci:integration` ラベル付き PR のみ実行）だが、**スクリプトを変更する PR で手動ラベル付与を忘れる**と main push 時まで統合テストが走らず、break を見逃すリスク。

### 修正

- `.github/workflows/labeler.yaml` を新規追加（`actions/labeler@v6.0.1`）
- `.github/labeler.yml` で対象パスを定義：
  - `install.sh`
  - `scripts/setup-local-ubuntu.sh`
  - `tests/integration/**`
  - `tests/smoke/**`
  - `.github/workflows/test-integration.yaml`
  - `.github/workflows/canary.yaml`

PR open / synchronize / reopen 時にこれらファイルの変更を検出すると自動で `ci:integration` ラベルが付き、統合テスト workflow が発火する。

## 設計判断

- **`pull_request` イベント使用**: 本プロジェクトは外部コントリビューション無し方針のため、`pull_request_target` の複雑さは不要
- **`sync-labels: false`**: 一度付いたラベルは後続コミットで外さない（手動削除を尊重）
- **SHA 固定**: `actions/labeler@634933ed...` で供給側の変更を即座に反映させない

## CONTRIBUTING.md 更新

`labeler.yaml` の追加を反映。統合テストラベルが自動付与されることを明記。

## Type of Change

- [x] CI/CD（運用改善）

## Testing

- [x] `yamllint` / `actionlint` / `markdownlint` パス
- [x] 本 PR 自体が `labeler.yaml` をテスト対象とし、自動で `ci:integration` ラベルが付くことを確認（起票後に手動確認）
- [x] lefthook pre-commit フックがパス
- [ ] 本 PR で `ci:integration` ラベルが自動付与されることを確認（本 PR の CI で検証）

## Checklist

- [x] プロジェクト規約に準拠
- [x] Linter がパス
- [x] セルフレビュー済み