### PR TITLE
docs: サポート Ubuntu 一覧（26.04 対応状況含む）を README に明記

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -27,6 +27,10 @@
 - `scripts/update-tools.sh` を新設し、mise / uv tool / npm / 独自インストーラを横断的に一括更新（`--dry-run` / `SETUP_LOG` 対応、#19）
 - `install.sh update` サブコマンド（上記スクリプトを呼び出す、#19）
 - `ensure_mise_installed` ヘルパー関数を追加（mise ベースのインストール関数で共通利用）
+- **層別テスト基盤**（#28 と Sub-Issues #29-#33）: smoke / BATS / Docker 統合 / 週次 Canary（`ubuntu:devel` + `ubuntu:rolling`）の各層に対応する GitHub Actions ワークフロー
+- **Ubuntu 26.04 Resolute Raccoon 対応**: Canary で次期 LTS 開発版に対する検証を継続。`wslu` が 26.04 の標準リポジトリから外れている問題に 3 段フォールバック（apt → PPA → 警告出して継続）を実装済み（#39）
+- **PR 自動ラベリング**（#46）: install/test 系パスを変更した PR に `ci:integration` ラベルを自動付与、手動タグ付け漏れによる統合テスト漏れを回避
+- **Canary 重複 Issue 抑止**（#46）: 同日複数失敗時は既存 Open Issue にコメントで再発を記録、重複起票を防止
 
 ### 削除
 
@@ -37,6 +41,8 @@
 ### ドキュメント
 
 - README.md / README.ja.md を AI ファースト・両モード対応を前提に再構成、新ツールと `update-tools.sh` を追記、動作確認コマンドを最新化
+- README にサポート Ubuntu リリース一覧表を追加（22.04 / 24.04 は CI 検証、25.10 / 26.04 は Canary 検証）
+- CONTRIBUTING.md を日本語で全面書き直し（内部成果物の日本語化方針に準拠）し、ローカルテスト実行手順 / WSL2 リリース前スモークチェック / Canary トリアージを追記
 
 ## [0.1.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `scripts/update-tools.sh` to batch-update every tool across mise / uv tool / npm / native installer backends. Supports `--dry-run` and `SETUP_LOG` (#19).
 - `install.sh update` subcommand that delegates to the new update script (#19).
 - `ensure_mise_installed` helper function reused across mise-managed install flows.
+- **Layered test infrastructure** (#28 and sub-issues #29-#33): smoke / BATS unit / Docker integration / weekly canary (`ubuntu:devel` + `ubuntu:rolling`) with GitHub Actions workflows for each layer.
+- **Ubuntu 26.04 (Resolute Raccoon) readiness**: canary workflow verifies the toolchain against the next LTS dev snapshot. Added a 3-stage fallback for `wslu` (apt → PPA → graceful warning) so 26.04 users can install without `wslu` blocking the whole setup (#39).
+- **PR auto-labeler** (#46): PRs touching install / test paths receive the `ci:integration` label automatically so integration tests run without manual tagging.
+- **Canary duplicate-issue prevention** (#46): repeated canary failures on the same day comment on the existing issue instead of creating duplicates.
 
 ### Removed
 
@@ -37,6 +41,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Docs
 
 - README.md / README.ja.md restructured to highlight AI-first, dual-mode (Dev Container / direct-host) workflows, document the new AI power tools and `update-tools.sh` script, and update verification commands.
+- README now advertises supported Ubuntu releases as a table (22.04 / 24.04 CI-verified, 25.10 / 26.04 canary-verified).
+- CONTRIBUTING.md rewritten in Japanese (matching the new Japanese-first internal artifact policy) with local test execution / WSL2 pre-release manual smoke checklist / canary triage.
 
 ## [0.1.0]
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -53,6 +53,7 @@ wsl-dev-setup/
 - 🔒 **モダンなシークレット検知** - gitleaks（2026 デファクト、アクティブメンテ）を mise で導入、プロジェクト側の lefthook と連携
 - 🎨 **シェル体験** - zsh + oh-my-zsh + プラグイン、fzf / ripgrep / fd / jq / tree / wslu
 - 🔄 **ワンショット更新** - `install.sh update` で mise / uv / npm 管理ツールを一括更新
+- 🐧 **Ubuntu LTS 幅広くサポート** - 22.04 / 24.04 を PR / main push で CI 検証、**次期 LTS 26.04 Resolute Raccoon** も週次 canary で先行検証済み。LTS 切替直後も動作する
 - ✅ **冪等性保証** - 複数回実行しても安全
 - 📝 **詳細なログ機能** - トラブルシューティング用のログ出力（オプション）
 - 🛠️ **統一的なエラーハンドリング** - わかりやすいエラーメッセージと対処法
@@ -95,13 +96,24 @@ cd wsl-dev-setup
 
 これらのスクリプトは **WSL2/Ubuntu ホスト**のセットアップを目的としており、以下 2 つのワークフローに等しく対応します。
 
-### 5.1 Dev Container ワークフロー（推奨）
+### 5.1 サポート対象 Ubuntu リリース
+
+| リリース | 状態 |
+|---|---|
+| **22.04 LTS (Jammy Jellyfish)** | ✅ 全 PR / main push で CI 検証済み |
+| **24.04 LTS (Noble Numbat)** | ✅ 全 PR / main push で CI 検証済み |
+| **25.10 (Questing Quokka)** | ✅ 週次 Canary で検証済み |
+| **26.04 LTS (Resolute Raccoon)** | ✅ 週次 Canary で検証済み — 次期 LTS 切替直後から動作する |
+
+週次の Canary ワークフローが `ubuntu:devel` / `ubuntu:rolling` Docker タグに対して統合 harness を実行し、パッケージ名変更・PPA 廃止・インストーラ仕様変更などの上流破壊的変更を次期 LTS リリース前に検知します。
+
+### 5.2 Dev Container ワークフロー（推奨）
 
 - ホストには最小限の基盤（Docker / mise / git / AI CLI / AI パワーツール）のみ配置
 - プロジェクト固有のランタイム・リンター・フォーマッターは各 `.devcontainer/` 内で管理
 - 複数プロジェクトで dev container を使い分けるチームに最適
 
-### 5.2 直接開発ワークフロー
+### 5.3 直接開発ワークフロー
 
 - Node.js LTS / pnpm / Python / uv も mise でホストに導入し、WSL 上で直接開発可能
 - プロジェクト固有のツールはプロジェクトの `.mise.toml` で管理

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ wsl-dev-setup/
 - 🔒 **Modern Secret Scanning** - gitleaks (2026 de-facto, actively maintained); pair with lefthook per project
 - 🎨 **Shell Experience** - zsh + oh-my-zsh + plugins, fzf / ripgrep / fd / jq / tree / wslu
 - 🔄 **One-shot Upgrades** - `install.sh update` batch-refreshes mise/uv/npm-managed tools
+- 🐧 **Ubuntu LTS Coverage** - CI-verified on 22.04 + 24.04; canary-tested on **26.04 Resolute Raccoon** (next LTS) so the toolchain continues to work the day 26.04 lands on WSL2
 - ✅ **Idempotency** - Safe to run multiple times
 - 📝 **Detailed Logging** - Optional log output for troubleshooting
 - 🛠️ **Unified Error Handling** - Clear error messages with actionable solutions
@@ -95,13 +96,24 @@ cd wsl-dev-setup
 
 These scripts are designed to set up the **WSL2/Ubuntu host**, and support both workflows below.
 
-### 5.1 Dev Container workflow (recommended)
+### 5.1 Supported Ubuntu releases
+
+| Release | Status |
+|---|---|
+| **22.04 LTS (Jammy Jellyfish)** | ✅ CI-verified every PR / main push |
+| **24.04 LTS (Noble Numbat)** | ✅ CI-verified every PR / main push |
+| **25.10 (Questing Quokka)** | ✅ Canary-verified weekly |
+| **26.04 LTS (Resolute Raccoon)** | ✅ Canary-verified weekly — ready for the next LTS the day it lands |
+
+The weekly canary workflow runs the full integration harness against `ubuntu:devel` and `ubuntu:rolling` Docker tags so upstream breaking changes (package renames, PPA removals, installer quirks) are caught before the next LTS ships.
+
+### 5.2 Dev Container workflow (recommended)
 
 - Host carries the bare minimum: Docker, mise, git, AI CLIs, AI power tools
 - Project-specific runtimes, linters, and formatters live inside each `.devcontainer/`
 - Matches the common team workflow where every project defines its own dev container
 
-### 5.2 Direct-host workflow
+### 5.3 Direct-host workflow
 
 - Host also installs Node.js LTS, pnpm, Python, uv via mise so you can develop directly on WSL
 - Per-project tools are managed via the project's own `.mise.toml`


### PR DESCRIPTION
## 概要

次期 LTS（Ubuntu 26.04 Resolute Raccoon）への対応状況を README / CHANGELOG で外部ユーザーへアピール。

## 動機

本ツールは PR #39 / #44 の wslu フォールバック実装および Canary ワークフロー（`ubuntu:devel` / `ubuntu:rolling`）により、**次期 LTS 切替直後から動作する状態**にあるが、README でそれを明示していなかった。2026 年 4 月の 26.04 リリースが目前のため、ユーザーが「このツールは新 LTS でも使える」と即座に判断できるよう可視化する。

## 変更内容

### README.md / README.ja.md

#### 1. Features セクションに「Ubuntu LTS カバー」項目を追加

> 🐧 **Ubuntu LTS Coverage** - CI-verified on 22.04 + 24.04; canary-tested on **26.04 Resolute Raccoon** (next LTS) so the toolchain continues to work the day 26.04 lands on WSL2

#### 2. Prerequisites に「Supported Ubuntu releases」節を追加

| Release | Status |
|---|---|
| **22.04 LTS (Jammy Jellyfish)** | ✅ CI-verified every PR / main push |
| **24.04 LTS (Noble Numbat)** | ✅ CI-verified every PR / main push |
| **25.10 (Questing Quokka)** | ✅ Canary-verified weekly |
| **26.04 LTS (Resolute Raccoon)** | ✅ Canary-verified weekly — ready for the next LTS the day it lands |

既存の 5.1 / 5.2 節は 5.2 / 5.3 に繰り下げ（TOC は `5. Prerequisites` のみ参照のため影響なし、内部参照も無し）。

### CHANGELOG.md / CHANGELOG.ja.md

Added / Docs セクションに以下を追記：

- 層別テスト基盤（#28 系列）の導入
- Ubuntu 26.04 対応（wslu fallback）
- PR 自動ラベリング（#46）
- Canary 重複 Issue 抑止（#46）
- README のサポート Ubuntu リリース表追加
- CONTRIBUTING.md の日本語化

## Type of Change

- [x] Documentation

## Testing

- [x] `markdownlint-cli2` が 4 ファイルともパス
- [x] 英語・日本語で同等内容を揃えた
- [x] 既存 5.1 / 5.2 節の内部参照が無いことを確認
- [x] lefthook pre-commit フックがパス

## Checklist

- [x] プロジェクト規約に準拠
- [x] Linter がパス
- [x] セルフレビュー済み