### PR TITLE
fix: curl|bash 経由実行時の unbound variable / read EOF を修正

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -130,7 +130,12 @@ main() {
 
   local tmp_dir
   tmp_dir="$(mktemp -d)"
-  trap 'rm -rf "$tmp_dir"' EXIT
+  # trap は EXIT 発火時点（main 関数を抜けた後）にも評価されるため、
+  # local 変数を遅延展開すると set -u 下で unbound variable になる。
+  # ここでは tmp_dir の値を即時展開して固定文字列としてトラップに焼き込む。
+  # mktemp -d はシングルクォートを含むパスを返さないため安全。
+  # shellcheck disable=SC2064  # 即時展開は意図的（local スコープ問題の回避）
+  trap "rm -rf -- '$tmp_dir'" EXIT
 
   local archive_url
   archive_url="https://codeload.github.com/${REPO_OWNER}/${REPO_NAME}/tar.gz/${ref}"

--- a/scripts/setup-zsh-ubuntu.sh
+++ b/scripts/setup-zsh-ubuntu.sh
@@ -14,6 +14,53 @@ INSTALL_COMPLETIONS=1
 INSTALL_HISTORY_SUBSTRING_SEARCH=1
 
 # ========================================
+# 対話/非対話モード制御
+# ========================================
+
+# 非対話モードかどうかを判定
+# WSL_DEV_SETUP_ASSUME_YES=1 or CI=true でプロンプトを自動回答する
+_is_non_interactive() {
+  [ "${WSL_DEV_SETUP_ASSUME_YES:-0}" = "1" ] || [ "${CI:-}" = "true" ]
+}
+
+# パイプ実行時 (curl ... | bash) でも対話プロンプトが動作するよう、
+# stdin が tty でなく /dev/tty が読める場合は /dev/tty にフォールバックする。
+# 非対話モード（CI / ASSUME_YES）ではフォールバックしない。
+if [ ! -t 0 ] && [ -r /dev/tty ] && ! _is_non_interactive; then
+  exec </dev/tty
+fi
+
+# [Y/n] プロンプト（既定 Y）を処理し、REPLY に結果を設定する
+# 非対話時は read をスキップして REPLY=Y を即設定
+# $1: プロンプト文字列
+_prompt_default_yes() {
+  local prompt="$1"
+  if _is_non_interactive; then
+    REPLY=Y
+    printf '%sY (non-interactive)\n' "$prompt"
+    return 0
+  fi
+  REPLY=""
+  read -p "$prompt" -n 1 -r || true
+  echo ""
+}
+
+# [y/N] プロンプト（既定 N）を処理し、REPLY に結果を設定する
+# 非対話時は read をスキップして REPLY=N を即設定
+# $1: プロンプト文字列
+_prompt_default_no() {
+  local prompt="$1"
+  if _is_non_interactive; then
+    REPLY=N
+    printf '%sN (non-interactive)\n' "$prompt"
+    return 0
+  fi
+  REPLY=""
+  read -p "$prompt" -n 1 -r || true
+  echo ""
+}
+
+# ========================================
 # ユーティリティ関数
 # ========================================
 
@@ -261,8 +308,7 @@ fi
 if ! grep -qi "ubuntu\|debian" /etc/os-release 2>/dev/null; then
   echo "⚠️  このスクリプトは Ubuntu/Debian 系ディストリビューション用です"
   echo "ℹ️  現在の OS: $(grep PRETTY_NAME /etc/os-release | cut -d'"' -f2)"
-  read -p "続行しますか？ (y/N): " -n 1 -r
-  echo
+  _prompt_default_no "続行しますか？ (y/N): "
   echo "ℹ️  ユーザー入力: $REPLY" # ログに記録
   if [[ ! $REPLY =~ ^[Yy]$ ]]; then
     echo "スクリプトを中止しました"
@@ -291,8 +337,8 @@ echo "すべてのプラグインをインストールしますか？"
 echo "  y: すべてインストール（デフォルト）"
 echo "  n: 個別に選択"
 echo ""
-read -p "選択 [Y/n]: " -n 1 -r INSTALL_ALL_PLUGINS
-echo ""
+_prompt_default_yes "選択 [Y/n]: "
+INSTALL_ALL_PLUGINS="$REPLY"
 echo "ℹ️  ユーザー入力: ${INSTALL_ALL_PLUGINS:-Y}"
 
 if [[ ! $INSTALL_ALL_PLUGINS =~ ^[Yy]?$ ]]; then
@@ -303,23 +349,19 @@ if [[ ! $INSTALL_ALL_PLUGINS =~ ^[Yy]?$ ]]; then
   echo ""
 
   # zsh-completions
-  read -p "📚 zsh-completions (追加の補完定義) をインストールしますか? [Y/n]: " -n 1 -r
-  echo ""
+  _prompt_default_yes "📚 zsh-completions (追加の補完定義) をインストールしますか? [Y/n]: "
   [[ $REPLY =~ ^[Nn]$ ]] && INSTALL_COMPLETIONS=0
 
   # zsh-autosuggestions
-  read -p "💡 zsh-autosuggestions (コマンド補完候補) をインストールしますか? [Y/n]: " -n 1 -r
-  echo ""
+  _prompt_default_yes "💡 zsh-autosuggestions (コマンド補完候補) をインストールしますか? [Y/n]: "
   [[ $REPLY =~ ^[Nn]$ ]] && INSTALL_AUTOSUGGESTIONS=0
 
   # zsh-history-substring-search
-  read -p "🔍 zsh-history-substring-search (履歴検索強化) をインストールしますか? [Y/n]: " -n 1 -r
-  echo ""
+  _prompt_default_yes "🔍 zsh-history-substring-search (履歴検索強化) をインストールしますか? [Y/n]: "
   [[ $REPLY =~ ^[Nn]$ ]] && INSTALL_HISTORY_SUBSTRING_SEARCH=0
 
   # zsh-syntax-highlighting
-  read -p "🎨 zsh-syntax-highlighting (シンタックスハイライト) をインストールしますか? [Y/n]: " -n 1 -r
-  echo ""
+  _prompt_default_yes "🎨 zsh-syntax-highlighting (シンタックスハイライト) をインストールしますか? [Y/n]: "
   [[ $REPLY =~ ^[Nn]$ ]] && INSTALL_SYNTAX_HIGHLIGHTING=0
 fi
 

--- a/tests/integration/entrypoint.sh
+++ b/tests/integration/entrypoint.sh
@@ -78,4 +78,45 @@ for anchor in \
   fi
 done
 
-printf '\n✅ Integration test passed (both runs completed, no shell config duplication)\n'
+printf '\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n'
+printf '🔵 Pipe-mode regression (curl|bash style)\n'
+printf '━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n'
+
+# README §4 で案内している `curl ... | bash -s -- ...` 実行形態の回帰テスト。
+# 過去に以下 2 件のバグがどのテスト層でも検出されなかったため、
+# pipe 経由の実行を明示的に踏ませて回帰を防ぐ:
+#   1. install.sh の EXIT trap が `local tmp_dir` を遅延展開し、
+#      set -u 下で unbound variable で死ぬ
+#   2. setup-zsh-ubuntu.sh の `read -p` が pipe 越し EOF + set -e で
+#      入力プロンプト到達と同時に終了する
+
+# --- 1. install.sh の EXIT trap が pipe 経由でも安全に発火することを確認 ---
+# 存在しない ref を指定して download を確実に失敗させ、EXIT trap が
+# unbound variable で死んでいないことだけを検証する（set -u 違反の検出）。
+PIPE_INSTALL_LOG="/tmp/pipe-install.log"
+cat /workspace/install.sh |
+  WSL_DEV_SETUP_REF="non-existent-ref-for-trap-regression-$$" bash -s -- local \
+    >"$PIPE_INSTALL_LOG" 2>&1 || true
+if grep -qE "unbound variable" "$PIPE_INSTALL_LOG"; then
+  echo "❌ install.sh emitted 'unbound variable' under pipe execution:"
+  grep -E "unbound variable" "$PIPE_INSTALL_LOG" || true
+  exit 1
+fi
+echo "✅ install.sh EXIT trap is safe under pipe execution"
+
+# --- 2. setup-zsh-ubuntu.sh が pipe 経由でも完走することを確認 ---
+# CI=true により非対話モードで実行され、対話プロンプトはすべて既定値で
+# 自動回答される。read -p が EOF で失敗していれば set -e で即死する。
+PIPE_ZSH_LOG="/tmp/pipe-zsh.log"
+if ! cat /workspace/scripts/setup-zsh-ubuntu.sh | bash >"$PIPE_ZSH_LOG" 2>&1; then
+  echo "❌ setup-zsh-ubuntu.sh failed under pipe execution. Log:"
+  cat "$PIPE_ZSH_LOG"
+  exit 1
+fi
+if grep -qE "unbound variable" "$PIPE_ZSH_LOG"; then
+  echo "❌ setup-zsh-ubuntu.sh emitted 'unbound variable' under pipe execution"
+  exit 1
+fi
+echo "✅ setup-zsh-ubuntu.sh completes under pipe execution"
+
+printf '\n✅ Integration test passed (both runs completed, no shell config duplication, pipe-mode OK)\n'

--- a/tests/smoke/run.sh
+++ b/tests/smoke/run.sh
@@ -96,6 +96,19 @@ assert_failure "install.sh rejects unknown flag" \
 assert_failure "install.sh rejects unknown positional arg" \
   bash install.sh unknown-subcommand
 
+# README §4 のクイックスタートで案内している `curl ... | bash -s -- ...`
+# 実行形態のサニティチェック。pipe 経由で実行されると BASH_SOURCE[0] が
+# ファイルとして存在しないため、install.sh はダウンロード経路に入る。
+# 過去に `local tmp_dir` を参照する EXIT trap が set -u 下で unbound に
+# なる回帰があったため、--help でも pipe 経路のスモークを残す。
+assert_stdout_contains "install.sh works via stdin pipe (curl|bash style)" \
+  "Usage:" \
+  bash -c 'cat install.sh | bash -s -- --help'
+
+assert_stdout_contains "install.sh --ref accepts value via stdin pipe" \
+  "Usage:" \
+  bash -c 'cat install.sh | bash -s -- --ref main --help'
+
 # ------------------------------------------------------------------
 # 2. update-tools.sh の引数解析 / --dry-run
 # ------------------------------------------------------------------


### PR DESCRIPTION
## 概要

README §4 のクイックスタート `curl ... | bash -s -- ...` に 2 件の回帰が混入しており、いずれのテスト層でも検出できていなかった。両バグを修正し、回帰テストを追加する。

## 不具合の症状

`curl ... | bash -s -- zsh` を実行するとプラグイン選択プロンプト直後に以下が出て中断する:

```
すべてのプラグインをインストールしますか？
  y: すべてインストール（デフォルト）
  n: 個別に選択

main: line 1: tmp_dir: unbound variable
```

## 根本原因

| # | バグ | 場所 |
|---|---|---|
| 1 | `set -e` 下で `read -p` が pipe 越し EOF で失敗し即終了 | `scripts/setup-zsh-ubuntu.sh` の対話プロンプト群 |
| 2 | EXIT trap が `local tmp_dir` を遅延展開し、main を抜けた後の発火時に set -u 違反 | `install.sh:131-133` |

バグ 1 が表面化し、バグ 1 起因の異常終了が EXIT trap を発火させてバグ 2 を露出させる、という 2 段重ね。

## なぜテストで検出できなかったか

- **smoke**: `bash -n` 構文チェックのみ（trap の遅延展開は valid な構文）。pipe 経由実行を踏ませていない
- **integration**: コンテナ内で `/workspace/install.sh local` を**ファイルパス経由**で実行 → ダウンロード経路（trap セット箇所）に入らず、また `zsh` サブコマンドもカバー外
- 結果として、**README に書いてある "正規の使い方" を再現するテストが存在しなかった**

## 修正内容

### バグ修正

- **install.sh**: EXIT trap を即時展開（double quote）に変更し、`local tmp_dir` のスコープに依存しないよう焼き込む
- **scripts/setup-zsh-ubuntu.sh**:
  - `/dev/tty` フォールバック（pipe 越しでも対話プロンプトが動く）
  - `CI=true` / `WSL_DEV_SETUP_ASSUME_YES=1` で非対話モード（既存 setup-local-ubuntu.sh と同等の `_prompt_default_yes` / `_prompt_default_no` ヘルパーを導入）

### 追加テスト

- **tests/smoke/run.sh**: `cat install.sh | bash -s -- --help` の pipe 実行サニティを 2 ケース追加
- **tests/integration/entrypoint.sh**: pipe 経由で
  1. install.sh の EXIT trap が unbound variable で死なないこと
  2. setup-zsh-ubuntu.sh が EOF で死なずに完走すること
  をそれぞれ検証

## Test plan

- [x] `bash tests/smoke/run.sh` が 13/13 pass
- [x] `shellcheck --severity=warning` clean
- [x] `gitleaks detect` no leaks
- [x] `cat install.sh | WSL_DEV_SETUP_REF=non-existent bash -s -- local` で unbound variable が出ない（手動確認済み）
- [ ] integration テスト（CI で 22.04 / 24.04 を検証）