### PR TITLE
fix: setup-local-ubuntu.sh も pipe 経由で対話プロンプトを受け付ける

### DIFF
--- a/scripts/setup-local-ubuntu.sh
+++ b/scripts/setup-local-ubuntu.sh
@@ -53,6 +53,13 @@ _is_non_interactive() {
   [ "${WSL_DEV_SETUP_ASSUME_YES:-0}" = "1" ] || [ "${CI:-}" = "true" ]
 }
 
+# パイプ実行時 (curl ... | bash) でも対話プロンプトが動作するよう、
+# stdin が tty でなく /dev/tty が読める場合は /dev/tty にフォールバックする。
+# 非対話モード（CI / ASSUME_YES）ではフォールバックしない。
+if [ ! -t 0 ] && [ -r /dev/tty ] && ! _is_non_interactive; then
+  exec </dev/tty
+fi
+
 # [Y/n] プロンプト（既定 Y）を処理し、REPLY に結果を設定する
 # 非対話時は read をスキップして REPLY=Y を即設定
 # $1: プロンプト文字列

--- a/tests/integration/entrypoint.sh
+++ b/tests/integration/entrypoint.sh
@@ -119,4 +119,20 @@ if grep -qE "unbound variable" "$PIPE_ZSH_LOG"; then
 fi
 echo "✅ setup-zsh-ubuntu.sh completes under pipe execution"
 
+# --- 3. setup-local-ubuntu.sh が pipe 経由でも完走することを確認 ---
+# CI=true により非対話モードで実行される。pipe 経由実行で stdin が EOF で
+# あっても、/dev/tty フォールバックまたは _is_non_interactive 分岐により
+# プロンプトが安全に処理されることを確認する。
+PIPE_LOCAL_LOG="/tmp/pipe-local.log"
+if ! cat /workspace/scripts/setup-local-ubuntu.sh | bash >"$PIPE_LOCAL_LOG" 2>&1; then
+  echo "❌ setup-local-ubuntu.sh failed under pipe execution. Log tail:"
+  tail -50 "$PIPE_LOCAL_LOG"
+  exit 1
+fi
+if grep -qE "unbound variable" "$PIPE_LOCAL_LOG"; then
+  echo "❌ setup-local-ubuntu.sh emitted 'unbound variable' under pipe execution"
+  exit 1
+fi
+echo "✅ setup-local-ubuntu.sh completes under pipe execution"
+
 printf '\n✅ Integration test passed (both runs completed, no shell config duplication, pipe-mode OK)\n'


### PR DESCRIPTION
## 背景

PR #48 のフォローアップ。`curl ... | bash -s -- local` で実利用者から **「y を入力していないのに勝手に進んだ」** との報告。

PR #48 では `setup-zsh-ubuntu.sh` のみ `/dev/tty` フォールバックを入れたが、`setup-local-ubuntu.sh` も同様に pipe 越し EOF で対話プロンプトが空 REPLY に倒れる（`read || true` で死なないが、ユーザーが**回答する機会自体を失う**）。

## 修正

- `scripts/setup-local-ubuntu.sh`: `setup-zsh-ubuntu.sh` と同じ条件式で `/dev/tty` フォールバックの `exec` を追加
- `tests/integration/entrypoint.sh`: pipe 経由で `setup-local-ubuntu.sh` を踏ませる回帰ケースを追加（既存の install.sh / setup-zsh-ubuntu.sh 用 pipe-mode ブロックの末尾）

## Test plan

- [x] `bash tests/smoke/run.sh` が 13/13 pass
- [x] `shellcheck --severity=warning` clean
- [x] `gitleaks detect` no leaks
- [ ] integration テスト（CI で 22.04 / 24.04 を検証 — pipe-mode で setup-local-ubuntu.sh の完走確認を追加）

## 関連

- PR #48 (curl|bash 経由実行時の unbound variable / read EOF 修正)
- 別件として ozzy-3/dotfiles#2 (mise の廃止 setting `pipx_uvx` 削除)