### PR TITLE
fix: mise --global 操作の override WARN を抑制

### DIFF
--- a/scripts/setup-local-ubuntu.sh
+++ b/scripts/setup-local-ubuntu.sh
@@ -423,6 +423,15 @@ install_git_security_tools() {
   echo "✅ Git セキュリティツールインストール完了"
 }
 
+# mise を $HOME ディレクトリで実行するラッパー
+# リポジトリ内（CWD に .mise.toml がある場所）で `--global` 操作を行うと
+# mise が「ローカル設定がグローバルを上書きする」WARN を毎回出すため、
+# サブシェルで $HOME に移動してから呼び出す。`--global` の書き先は
+# ~/.config/mise/config.toml で CWD の影響を受けないため、挙動は同じ。
+_mise_at_home() {
+  (cd "$HOME" && "$MISE_BIN" "$@")
+}
+
 # mise でグローバルツールを導入する汎用ヘルパー
 # $1: tool_spec（例: node@lts, python@latest, gitleaks@latest）
 # $2: display_name（表示名）
@@ -437,12 +446,12 @@ mise_use_global() {
   fi
 
   # 既にグローバル設定済みかを確認
-  if "$MISE_BIN" ls --global 2>/dev/null | awk '{print $1}' | grep -qx "$tool_name"; then
-    "$MISE_BIN" use --global "$tool_spec" >/dev/null 2>&1 || true
-    "$MISE_BIN" install "$tool_spec" >/dev/null 2>&1 || true
+  if _mise_at_home ls --global 2>/dev/null | awk '{print $1}' | grep -qx "$tool_name"; then
+    _mise_at_home use --global "$tool_spec" >/dev/null 2>&1 || true
+    _mise_at_home install "$tool_spec" >/dev/null 2>&1 || true
     echo "  ⏭️  $display_name は導入済み・最新化しました"
   else
-    if "$MISE_BIN" use --global "$tool_spec" >/dev/null; then
+    if _mise_at_home use --global "$tool_spec" >/dev/null; then
       echo "  ✅ $display_name インストール完了"
     else
       echo "  ⚠️  $display_name のインストールに失敗しました"
@@ -659,7 +668,7 @@ install_ai_tools() {
   # mise 管理下の node で npm グローバルインストールした CLI のシムを生成
   # （Codex / Gemini 等の新規バイナリを ~/.local/share/mise/shims 経由で使えるようにする）
   if [ "$any_installed" = "1" ] && [ -x "$MISE_BIN" ]; then
-    "$MISE_BIN" reshim >/dev/null 2>&1 || true
+    _mise_at_home reshim >/dev/null 2>&1 || true
   fi
 
   [ "$any_installed" = "1" ] && echo "✅ AIツールインストール完了"

--- a/scripts/update-tools.sh
+++ b/scripts/update-tools.sh
@@ -49,6 +49,11 @@ fi
 
 MISE_BIN="$HOME/.local/bin/mise"
 
+# 全ての更新コマンドは CWD に依存しない。一方、リポジトリ内（CWD に .mise.toml が
+# ある場所）で実行すると mise が「ローカル設定がグローバルを上書きする」WARN を
+# 毎回出すため、ここで $HOME に移動してから残りを実行する。
+cd "$HOME"
+
 run_or_preview() {
   local description="$1"
   shift


### PR DESCRIPTION
## 背景

`./install.sh local` / `./install.sh update` を **wsl-dev-setup リポジトリ内で実行**すると、対象ツールごとに以下の WARN が出ていた:

\`\`\`
mise WARN  node is defined in .../wsl-dev-setup/.mise.toml which overrides the global config (~/.config/mise/config.toml)
\`\`\`

実利用者から指摘あり。

## 原因

- リポジトリ自身の開発・CI 用に `wsl-dev-setup/.mise.toml` で node/pnpm/gitleaks/shellcheck 等のバージョンをピン留めしている
- ユーザーのグローバル `~/.config/mise/config.toml` でも同じツールを定義
- スクリプトが**リポジトリ内 CWD のまま** `mise use --global` / `mise install` / `mise upgrade` / `mise reshim` を呼んでいたため、mise が「ローカルがグローバルを上書き」と毎回通知

機能上は問題ないが、グローバル更新を**意図した**操作で毎回出るのは UX を損ねる。

## 修正

- **scripts/setup-local-ubuntu.sh**: `_mise_at_home` ラッパーを追加し、`mise_use_global` 内の各 mise 呼び出しと AI ツール導入後の `mise reshim` をサブシェル経由で \`\$HOME\` から実行
- **scripts/update-tools.sh**: スクリプト全体が CWD 非依存のため、起動直後に \`cd "\$HOME"\` する単純化アプローチを採用（\`--dry-run\` 表示で実コマンドが見える自然さも維持）

\`--global\` の書き先 \`~/.config/mise/config.toml\` は元から CWD 非依存のため、挙動はまったく変わらず WARN だけが消える。

## Test plan

- [x] \`bash tests/smoke/run.sh\` が 13/13 pass
- [x] \`shellcheck --severity=warning\` clean
- [x] \`gitleaks detect\` no leaks
- [x] \`bash scripts/update-tools.sh --dry-run\` で実コマンド (\`/home/.../mise upgrade\` 等) が表示されることを目視確認
- [ ] integration テスト (CI で 22.04 / 24.04 を検証)

## 関連

- PR #48, #49: curl|bash 経由実行時の不具合修正シリーズ（本 PR で wsl-dev-setup 側の WARN クリーンアップを締め）