### PR TITLE
chore: dev-config の同期差分を反映

### DIFF
--- a/.agents/skills/commit-conventions/SKILL.md
+++ b/.agents/skills/commit-conventions/SKILL.md
@@ -31,9 +31,7 @@ Conventional Commits 1.0.0 に準拠する（commitlint で検証される）。
 
 ## メッセージ本文
 
-- 1 行目: `type[(scope)]: description`
-  - `type` / `scope` は英語（Conventional Commits 規約）
-  - `description` は**日本語**で、50 文字以内目安
+- 1 行目: `type[(scope)]: description`（英語で、50 文字以内目安）
 - 複数の論理的変更がある場合は body で補足
 
 ## 共通注意事項

--- a/.claude/rules/git-workflow.md
+++ b/.claude/rules/git-workflow.md
@@ -1,23 +1,10 @@
 # Git ワークフロールール
 
-## 言語ポリシー
-
-本プロジェクトは個人開発で、外部コントリビューションを受ける予定はない。メンテナは日本語ネイティブのため、**内部成果物は日本語優先**。外部ユーザー向けドキュメントのみ英語版を併記する。
-
-| 層 | 対象 | 言語 |
-|---|---|---|
-| **外部向け** | `README.md` / `CHANGELOG.md` | 英語 |
-| **外部向け** | `README.ja.md` / `CHANGELOG.ja.md` | 日本語 |
-| **内部向け** | コミット description / PR タイトル・本文 / Issue / ブランチ名の説明部分を除く全て | **日本語** |
-| **形式規約** | コミット・PR タイトルの `<type>:` プレフィックス | 英語（Conventional Commits） |
-| **形式規約** | ブランチ名の `<short-description>` 部分 | 英字推奨（URL・ツール互換性のため） |
-
 ## ブランチ
 
 - `main` から新しいブランチを作成する
 - 命名規則: `<type>/<short-description>`（例: `feat/add-blog`, `fix/nav-error`）
 - type: feat, fix, docs, style, refactor, perf, test, build, ci, chore
-- `<short-description>` は英字 + ハイフンで記述する（URL・CI ツールの安全性のため）
 
 ## コミット
 
@@ -27,24 +14,14 @@ Conventional Commits 形式を使用する:
 <type>[optional scope]: <description>
 ```
 
-- `<type>` は上記のブランチ type と同一（英語）
-- `<description>` は**日本語**で、簡潔に変更内容を記述
-- 破壊的変更: type 後に `!`（例: `feat!: ランディングページを再設計`）
-
-### 例
-
-```text
-feat: mise を導入し Volta を置換
-refactor: Azure / Google Cloud CLI を opt-in に降格
-test: CLI エントリーポイントの smoke テストを追加
-docs: README を両モード対応 + 新ツール反映で更新
-```
+- type は上記のブランチ type と同一
+- description は英語で、簡潔に変更内容を記述
+- 破壊的変更: type 後に `!`（例: `feat!: redesign landing page`）
 
 ## PR
 
 - マージ方法: **squash merge のみ**
-- PR タイトル: `<type>[optional scope]: <description>`（コミット規約と同じ形式、description は日本語）
-- PR 本文も**日本語**で記述する
+- PR タイトル: `<type>[optional scope]: <description>`（コミット規約と同じ形式）
 - マージ後に feature branch を削除する
 
 ## Git フック

--- a/.dev-config/sync.yaml
+++ b/.dev-config/sync.yaml
@@ -6,6 +6,7 @@ pinned:
   - .devcontainer/Dockerfile
   - .devcontainer/devcontainer.json
   - .devcontainer/initialize.sh
+  - .gitignore
   - .markdownlint-cli2.yaml
   - .mise.toml
   - .mcp.json

--- a/.dev-config/sync.yaml
+++ b/.dev-config/sync.yaml
@@ -1,7 +1,7 @@
 # Auto-updated by dev-config sync.sh
 # 'pinned' is user-editable — add or remove paths freely
-commit: 36477e1
-synced_at: 2026-04-12T22:33:14Z
+commit: 6a8bffd
+synced_at: 2026-04-18T06:54:31Z
 pinned:
   - .devcontainer/Dockerfile
   - .devcontainer/devcontainer.json

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,28 @@
+# GitHub Copilot Instructions
+
+共通方針は [AGENTS.md](../AGENTS.md) を参照してください。
+GitHub Copilot Chat / Copilot コーディングエージェントは本ファイルを自動で読み込みます。
+
+## 基本ルール
+
+- 日本語で応答する
+- 推奨案とその理由を提示する
+- `.env` ファイルは読み取り・ステージングしない
+- 破壊的な Git 操作を避ける
+
+## コミット・ブランチ・PR
+
+- Conventional Commits 形式（`<type>[scope]: <description>`）
+- ブランチ命名: `<type>/<short-description>`
+- PR はタイトルをコミット規約と同じ形式にする
+- マージ方法は squash merge のみ
+
+## 検証
+
+変更後は以下を通すこと:
+
+```bash
+mise exec -- lefthook run pre-commit --all-files
+```
+
+プロジェクト固有の検証は [AGENTS.md](../AGENTS.md) の「検証」セクションを参照。

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check PR title format
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
             const title = context.payload.pull_request.title;
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check branch name format
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
             const branch = context.payload.pull_request.head.ref;

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@ build/
 
 # Logs
 *.log
+
+# Claude Code ランタイム成果物（ScheduleWakeup などが生成するロック等）
+.claude/scheduled_tasks.lock
+.claude/*.lock

--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,3 @@ build/
 
 # Logs
 *.log
-
-# Claude Code ランタイム成果物（ScheduleWakeup などが生成するロック等）
-.claude/scheduled_tasks.lock
-.claude/*.lock

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,102 +1,11 @@
 # Contributing
 
-本プロジェクトは [ozzy-labs](https://github.com/ozzy-labs) が個人で運用しており、外部コントリビューションは受け付けていません。バグ報告や機能要望は Issue で歓迎します。
+This is a personal project maintained by [ozzy-labs](https://github.com/ozzy-labs). External contributions are not currently accepted.
 
-## 言語ポリシー
+## Bug Reports & Feature Requests
 
-- 外部ユーザー向けドキュメント（`README.md` / `CHANGELOG.md`）は英語・日本語の両方を用意
-- 内部成果物（コミット description / PR / Issue / コードコメント / CI 設定など）は**日本語**
-- 形式規約（Conventional Commits の `<type>:` プレフィックス、ブランチ名の `<type>/<slug>` 構造）は英語
-- 詳細は [`.claude/rules/git-workflow.md`](./.claude/rules/git-workflow.md) を参照
+If you find a bug or have an idea for improvement, please open an issue.
 
-## テスト
+## License
 
-### 非対話モード
-
-CI / Docker で対話プロンプトをスキップする際は、以下のいずれかを設定します：
-
-```bash
-WSL_DEV_SETUP_ASSUME_YES=1 ./install.sh local    # 明示的 opt-in
-CI=true ./install.sh local                        # ほとんどの CI で自動設定される標準変数
-```
-
-挙動：
-
-- `[Y/n]` プロンプト → 自動 `Y`（インストール）
-- `[y/N]` プロンプト（Azure CLI / Google Cloud CLI / 非 Ubuntu 確認）→ 自動 `N`（スキップ / 中止）
-- Git ユーザー名 / メール: 事前に `git config --global user.{name,email}` で設定しておけば既存の「設定済み」パスに乗る
-
-### ローカルでのテスト実行
-
-```bash
-# L0: Smoke tests（約 500ms、ネットワーク不要）
-./tests/smoke/run.sh
-
-# L1: Static analysis（通常は lefthook が commit 時に自動実行）
-mise exec -- shellcheck --severity=warning install.sh scripts/*.sh tests/smoke/run.sh tests/integration/*.sh
-mise exec -- shfmt -d install.sh scripts/*.sh tests/smoke/run.sh tests/integration/*.sh
-mise exec -- markdownlint-cli2 '**/*.md'
-mise exec -- yamllint -c .yamllint.yaml .github/workflows .mise.toml .yamllint.yaml lefthook.yaml lefthook-base.yaml .markdownlint-cli2.yaml
-mise exec -- actionlint .github/workflows/*.yaml
-mise exec -- gitleaks detect --no-banner --redact -v
-
-# L2: BATS ユニットテスト
-mise exec -- bats tests/unit/
-
-# L3: Docker 統合テスト（バージョン毎に約 5-10 分）
-./tests/integration/run.sh                 # デフォルト: ubuntu:24.04
-./tests/integration/run.sh 22.04 24.04     # 複数バージョン
-./tests/integration/run.sh devel           # Canary（次期 Ubuntu）
-```
-
-`tests/integration/run.sh` は `GITHUB_TOKEN`（環境変数 or `gh auth token`）を自動検出してコンテナに渡します。これにより mise の GitHub API レートリミットが 60 req/hr → 5000 req/hr に拡大し、短時間で繰り返しテストしても詰まらなくなります。
-
-### CI（GitHub Actions）
-
-| ワークフロー | トリガー | 内容 |
-|---|---|---|
-| `lint.yaml` | PR + main push | shellcheck / shfmt / markdownlint / yamllint / gitleaks |
-| `test-smoke.yaml` | PR + main push | `tests/smoke/run.sh` を実行（Docker 不要） |
-| `test-unit.yaml` | PR + main push | `mise` 経由で BATS スイートを実行 |
-| `test-integration.yaml` | main push / 手動 / `ci:integration` ラベル付き PR | 22.04 + 24.04 matrix で `tests/integration/run.sh` を実行 |
-| `canary.yaml` | 週次（月曜 03:00 UTC）+ 手動 | `ubuntu:devel` / `ubuntu:rolling` で統合 harness を実行し、失敗時に Issue 自動起票／既存 Open Issue があればコメントで再発を記録 |
-| `labeler.yaml` | PR (opened/synchronize/reopened) | `install.sh` / `scripts/setup-local-ubuntu.sh` / `tests/integration/**` / `tests/smoke/**` / 主要 CI を変更した PR に `ci:integration` ラベルを自動付与 |
-
-統合テストは PR では opt-in（1 バージョン約 5 分）で、コード変更のみの PR のフィードバックを高速に保ちます。統合テストが必要な範囲を変更する PR には `labeler.yaml` が自動で `ci:integration` ラベルを付与するため、通常は手動付与不要です。自動判定外のケースで必要な場合は手動付与も可能です。
-
-> **注意（GITHUB_TOKEN 起点のラベル付与制約）**: PR 初回 open 時に `labeler.yaml` が付けた `ci:integration` ラベルは、同時に走る `test-integration.yaml` の label チェックには間に合わないため、**初回のみ統合テストは skip**される。2 回目以降の push（`pull_request/synchronize`）では正常に発火する。初回から統合テストを走らせたい場合は、空コミット（`git commit --allow-empty`）で再 push するか、`gh workflow run test-integration.yaml --ref <branch>` で手動 dispatch する。
-
-### Canary トリアージ
-
-Canary ワークフローが失敗すると、`canary` + `investigation-needed` ラベル付きの Issue が自動起票されます。Issue 本文には run URL とトリアージチェックリストが含まれます：
-
-1. **apt パッケージ名の変更・削除** — 次期 Ubuntu でパッケージが rename / 廃止された可能性（例: `tesseract-ocr-jpn`）
-2. **PPA が新 Ubuntu 未対応** — `ppa:git-core/ppa` など
-3. **上流ツールの破壊的変更** — mise / gitleaks / ast-grep 等のメジャーバンプ
-4. **インストーラ仕様変更** — `mise.run` / `astral.sh/uv` 等の flag 変更
-5. **一時的なネットワーク問題** — `gh workflow run canary.yaml` で再実行して緑なら "transient" として close
-
-Canary 失敗はメインラインをブロックしません。次期 LTS リリース前に上流変更を検知し、事前対応の時間を確保するための仕組みです。
-
-### WSL2 実機スモークチェックリスト（リリース前）
-
-Docker は Ubuntu userspace を再現しますが、WSL2 固有要素（systemd / `wslu` / Windows interop）までは再現できません。リリース前に実機の WSL2/Ubuntu で以下を確認してください：
-
-- [ ] `install.sh zsh` が完走し、新しいターミナルで `echo $SHELL` が zsh を指す
-- [ ] `install.sh local` が完走し、`mise --version` / `node --version` / `pnpm --version` / `python3 --version` / `uv --version` / `gitleaks version` が動作する
-- [ ] 既存セットアップ済み環境で `install.sh update` がエラーなく完了する
-- [ ] `wslview https://example.com` で Windows 既定ブラウザが開く
-- [ ] `sudo service docker start` が成功し、`docker run --rm hello-world` が動作する
-- [ ] `echo $LANG` が `ja_JP.UTF-8`、`date` が JST 表示
-- [ ] `git config --global user.name` / `user.email` が意図通り設定されている
-- [ ] AI CLI 認証フロー（`claude auth login` / `codex auth login` / `copilot` / `gemini`）が正しく起動する
-
-### ブランチ保護の推奨設定（repo owner 向け）
-
-- `main` への直接 push 禁止
-- 必須ステータスチェック: `lint` / `test-smoke` / `test-unit`
-- `test-integration` は任意（`ci:integration` ラベル付き PR または main push で自動実行）
-
-## ライセンス
-
-本プロジェクトへの関与により、提供されるコントリビューションは [MIT License](LICENSE) で配布されることに同意するものとします。
+By interacting with this project, you agree that any contributions you make will be licensed under the [MIT License](LICENSE).


### PR DESCRIPTION
## 概要

`../dev-config/sync.sh --yes` を本リポに適用し、非 pinned ファイルを dev-config commit `6a8bffd` 時点の内容に揃えた。

## 変更内容

| ファイル | 種別 | 内容 |
|---|---|---|
| `.github/copilot-instructions.md` | 新規 | GitHub Copilot 用の共通指示ファイル |
| `.agents/skills/commit-conventions/SKILL.md` | 更新 | description の運用ルールを英語に統一 |
| `.claude/rules/git-workflow.md` | 更新 | 言語ポリシー節を削除、description を英語に |
| `.github/workflows/pr-check.yaml` | 更新 | `actions/github-script` を v9.0.0 → v8 にダウングレード（dev-config 側の pin に追随） |
| `.gitignore` | 更新 | `.claude/scheduled_tasks.lock` / `.claude/*.lock` の行を削除 |
| `CONTRIBUTING.md` | 更新 | 汎用テンプレートに簡素化（テスト手順・Canary トリアージ等は削除） |
| `.dev-config/sync.yaml` | 更新 | commit ポインタを `36477e1` → `6a8bffd` に、synced_at を更新 |

## 補足 — 本リポ固有情報の取り扱い

以下は dev-config の汎用テンプレートに統合された結果、本リポから失われた。ユーザー合意のもと「dist 版のまま採用」。

- `.claude/rules/git-workflow.md` の「言語ポリシー」節（README / CHANGELOG の二言語運用、内部成果物は日本語優先）
- `CONTRIBUTING.md` の非対話モード・L0〜L3 テスト手順・Canary トリアージ・WSL2 実機スモークチェックリスト

本リポの日本語優先方針は `CLAUDE.md` / `AGENTS.md` 側で引き続き担保する。

## pinned ファイル（同期対象外）

`.dev-config/sync.yaml` の pinned リストに従い、以下は既存の本リポ固有値を維持:

- `.devcontainer/{Dockerfile,devcontainer.json,initialize.sh}`
- `.markdownlint-cli2.yaml`, `.mise.toml`, `.mcp.json`
- `.vscode/{extensions.json,settings.json}`
- `biome.json`, `lefthook-base.yaml`, `renovate.json`, `trivy.yaml`

## テスト計画

- [x] markdownlint-cli2 / yamlfmt / yamllint / actionlint / gitleaks ローカル pass
- [x] lefthook pre-commit / commit-msg pass
- [ ] CI（lint / test-smoke / test-unit）緑