### PR TITLE
chore: sync commons defaults

### DIFF
--- a/.dev-config/sync.yaml
+++ b/.dev-config/sync.yaml
@@ -1,7 +1,7 @@
-# Auto-updated by dev-config sync.sh
+# Auto-updated by commons sync.sh
 # 'pinned' is user-editable — add or remove paths freely
-commit: 6a8bffd
-synced_at: 2026-04-18T06:54:31Z
+commit: 4f6de17bb3894eb2ad5d2f8f90e93dbc9d3b13ad
+synced_at: 2026-04-25T04:30:06Z
 pinned:
   - .devcontainer/Dockerfile
   - .devcontainer/devcontainer.json

--- a/.github/workflows/sync-commons.yaml
+++ b/.github/workflows/sync-commons.yaml
@@ -1,0 +1,74 @@
+name: Sync commons
+
+# Automated sync of shared configuration from ozzy-labs/commons.
+#
+# Runs on a weekly schedule (configurable) and on manual dispatch. When
+# the upstream commons repo has changes that are not yet reflected
+# in this repo (per `.dev-config/sync.yaml` state, minus `pinned`
+# entries), the workflow runs `sync.sh --yes` and opens a pull request
+# with the resulting diff. The PR is never auto-merged; review it.
+#
+# Prerequisites in the consumer repo:
+#   - Workflow permissions must allow creating PRs (usually set by
+#     commons/setup-repo.sh)
+#   - `.dev-config/sync.yaml` exists (created on first manual sync.sh run)
+on:
+  schedule:
+    # Every Monday 00:00 UTC
+    - cron: "0 0 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync:
+    name: Sync commons defaults
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout this repo
+        uses: actions/checkout@v4
+
+      - name: Clone commons
+        uses: actions/checkout@v4
+        with:
+          repository: ozzy-labs/commons
+          path: .sync-commons
+          fetch-depth: 1
+
+      - name: Detect diff and run sync
+        id: sync
+        run: |
+          set -e
+          if bash .sync-commons/sync.sh --check "$GITHUB_WORKSPACE"; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No changes to sync."
+            exit 0
+          fi
+          bash .sync-commons/sync.sh --yes "$GITHUB_WORKSPACE"
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Remove temporary clone
+        if: steps.sync.outputs.changed == 'true'
+        run: rm -rf .sync-commons
+
+      - name: Create Pull Request
+        if: steps.sync.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          branch: chore/sync-commons
+          base: main
+          commit-message: |
+            chore: sync commons defaults
+
+            Automated sync from ozzy-labs/commons.
+          title: "chore: sync commons defaults"
+          body: |
+            Automated sync from [ozzy-labs/commons](https://github.com/ozzy-labs/commons).
+
+            Files listed under `pinned` in `.dev-config/sync.yaml` are excluded.
+
+            Triggered by the scheduled `Sync commons` workflow. Review the diff and merge when appropriate.
+          labels: chore
+          delete-branch: true


### PR DESCRIPTION
Manual sync from [ozzy-labs/commons](https://github.com/ozzy-labs/commons) for the post-rename rollout.

## Changes

- `.dev-config/sync.yaml` — metadata comment refreshed to `# Auto-updated by commons sync.sh`
- `.github/workflows/sync-commons.yaml` — new scheduled sync workflow (Mon 00:00 UTC) that auto-opens future sync PRs
- `lefthook-base.yaml` — header comment refreshed to reference `commons` (where applicable)

Refs ozzy-labs/commons#59.