### PR TITLE
chore(skills-sync): switch renovate.json to umbrella skills-sync per ADR-0019

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,9 +2,6 @@
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
 	"extends": [
 		"github>ozzy-labs/.github",
-		"github>ozzy-labs/skills//skills-sync/claude-code",
-		"github>ozzy-labs/skills//skills-sync/codex-cli",
-		"github>ozzy-labs/skills//skills-sync/gemini-cli",
-		"github>ozzy-labs/skills//skills-sync/copilot"
+		"github>ozzy-labs/skills//skills-sync"
 	]
 }


### PR DESCRIPTION
## Summary

[ADR-0019](https://github.com/ozzy-labs/handbook/blob/main/adr/0019-adapter-aware-sync-conventions.md) で確定した consumer 側 canonical pattern に整合化する。

- `renovate.json` の per-adapter sub-preset extends（4 件）を umbrella `skills-sync` 1 件に統一
- `.dev-config/sync.yaml` は既に `skills_adapters` field を持つため変更なし

## Why

ADR-0019 Decision 2 に基づき、adapter 増減時の保守性 / handbook PoC との整合性 / 設定の簡潔性を優先する。Renovate PR ラベルが adapter ごとに分かれない trade-off は受容（bump 単位の細かい制御は現状不要）。

## Refs

- ozzy-labs/handbook#70 Acceptance #2
- [ADR-0019](https://github.com/ozzy-labs/handbook/blob/main/adr/0019-adapter-aware-sync-conventions.md)

## Test plan

- [ ] Renovate が umbrella `skills-sync` preset 経由で 4 adapter を引き続き監視している（merge 後の Renovate dashboard / 次回 bump PR で確認）
- [ ] CI が通る