### PR TITLE
feat(install): add bubblewrap to bootstrap tools

### DIFF
--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -31,6 +31,7 @@
 - **Ubuntu 26.04 Resolute Raccoon 対応**: Canary で次期 LTS 開発版に対する検証を継続。`wslu` が 26.04 の標準リポジトリから外れている問題に 3 段フォールバック（apt → PPA → 警告出して継続）を実装済み（#39）
 - **PR 自動ラベリング**（#46）: install/test 系パスを変更した PR に `ci:integration` ラベルを自動付与、手動タグ付け漏れによる統合テスト漏れを回避
 - **Canary 重複 Issue 抑止**（#46）: 同日複数失敗時は既存 Open Issue にコメントで再発を記録、重複起票を防止
+- Ubuntu/Debian のコンテナ / サンドボックスツールセットに apt 経由の `bubblewrap` を追加
 
 ### 削除
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Ubuntu 26.04 (Resolute Raccoon) readiness**: canary workflow verifies the toolchain against the next LTS dev snapshot. Added a 3-stage fallback for `wslu` (apt → PPA → graceful warning) so 26.04 users can install without `wslu` blocking the whole setup (#39).
 - **PR auto-labeler** (#46): PRs touching install / test paths receive the `ci:integration` label automatically so integration tests run without manual tagging.
 - **Canary duplicate-issue prevention** (#46): repeated canary failures on the same day comment on the existing issue instead of creating duplicates.
+- `bubblewrap` added to the Ubuntu/Debian container / sandbox tool set via apt.
 
 ### Removed
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -48,7 +48,7 @@ bootstrap/
 
 - 🤖 **AI エージェント CLI** - Claude Code / Codex CLI / GitHub Copilot CLI / Gemini CLI（個別選択可）
 - 🧠 **AI パワーツール** - markitdown（PDF/Office → Markdown）/ tesseract-ocr(+jpn) / ffmpeg / ast-grep（構造的コード検索）/ yq
-- 🐳 **コンテナ開発環境** - Docker Engine + Docker Compose（Dev Container の前提）
+- 🐳 **コンテナ / サンドボックス基盤** - Docker Engine + Docker Compose（Dev Container の前提）+ bubblewrap
 - ⚡ **統一バージョン管理** - mise で Node.js LTS / pnpm / Python / uv / gitleaks / shellcheck / ast-grep / yq を一元管理
 - 🐍 **Python エコシステム** - mise 管理の Python + uv（パッケージ・venv・CLI ツール）
 - ☁️ **クラウド CLI** - AWS CLI v2（デフォルト ON）/ Azure CLI, Google Cloud CLI（opt-in）
@@ -240,7 +240,8 @@ Ubuntu/Debian 環境（WSL2 + 非 WSL Linux：Ubuntu Server / EC2 / GCE / コン
    - **GitHub CLI** - GitHub 操作
    - **gitleaks**（mise 経由）- モダンなシークレットスキャナ。プロジェクト側の lefthook / pre-commit に組み込む運用
    - **Git 基本設定** - user.name, user.email, core.editor などの自動設定
-7. **コンテナツール**
+7. **コンテナ / サンドボックスツール**
+   - **bubblewrap** - モダンな CLI / デスクトップツールが利用する軽量な非特権サンドボックス基盤
    - **Docker Engine** - コンテナ実行環境
    - **Docker Compose** - 複数コンテナの管理ツール（Dev Container に必須）
    - **Docker サービス自動起動** - WSL2 でのサービス起動
@@ -359,6 +360,7 @@ exit
    yq --version
 
    # コンテナ + 開発補助
+   bwrap --version
    docker --version
    docker compose version
    just --version

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ bootstrap/
 
 - 🤖 **AI Agent CLIs** - Claude Code, Codex CLI, GitHub Copilot CLI, Gemini CLI (choose individually)
 - 🧠 **AI Power Tools** - markitdown (PDF/Office → Markdown), tesseract-ocr (+jpn), ffmpeg, ast-grep (structural code search), yq
-- 🐳 **Container Development** - Docker Engine + Docker Compose (essential for Dev Containers)
+- 🐳 **Container / Sandbox Foundation** - Docker Engine + Docker Compose (essential for Dev Containers) + bubblewrap
 - ⚡ **Unified Version Manager** - mise manages Node.js LTS / pnpm / Python / uv / gitleaks / shellcheck / ast-grep / yq
 - 🐍 **Python Ecosystem** - mise-managed Python + uv for packages/venvs/CLI tools
 - ☁️ **Cloud CLIs** - AWS CLI v2 (default) / Azure CLI, Google Cloud CLI (opt-in)
@@ -240,7 +240,8 @@ You can run it either through `install.sh` or directly via `scripts/setup-local-
    - **GitHub CLI** - GitHub operations
    - **gitleaks** (via mise) - Modern secret scanner; wire into project-level lefthook / pre-commit hooks
    - **Git basic config** - user.name, user.email, core.editor, etc.
-7. **Container Tools**
+7. **Container / Sandbox Tools**
+   - **bubblewrap** - Lightweight unprivileged sandboxing primitive used by modern CLI / desktop tooling
    - **Docker Engine** - Container runtime
    - **Docker Compose** - Multi-container management tool (essential for Dev Containers)
    - **Docker service auto-start** - Service startup on WSL2
@@ -359,6 +360,7 @@ exit
    yq --version
 
    # Container + dev utilities
+   bwrap --version
    docker --version
    docker compose version
    just --version

--- a/scripts/setup-local-ubuntu.sh
+++ b/scripts/setup-local-ubuntu.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 # shellcheck disable=SC2088  # チルダはログメッセージ内の表示用であり、パス展開は不要
+# shellcheck disable=SC2016  # シェル設定に遅延展開させる文字列をそのまま書き込む
+# shellcheck disable=SC1091  # /etc/os-release は実行環境で提供される
 set -e
 
 # ========================================
@@ -16,8 +18,8 @@ INSTALL_GIT_TOOLS="${INSTALL_GIT_TOOLS:-1}"     # Git, GitHub CLI, gitleaks
 INSTALL_NODE="${INSTALL_NODE:-1}"     # mise + Node.js LTS + pnpm
 INSTALL_PYTHON="${INSTALL_PYTHON:-1}" # mise + Python + uv
 
-# コンテナツール
-INSTALL_CONTAINER="${INSTALL_CONTAINER:-1}" # Docker, Docker Compose
+# コンテナ / サンドボックスツール
+INSTALL_CONTAINER="${INSTALL_CONTAINER:-1}" # Docker, Docker Compose, bubblewrap
 
 # クラウドツール（個別選択可能、Azure/GCP は opt-in）
 INSTALL_AWS_CLI="${INSTALL_AWS_CLI:-1}"       # AWS CLI (デフォルト ON)
@@ -155,7 +157,7 @@ setup_docker_repository() {
 # 3. Git/バージョン管理ツール（git, gh）
 # 4. mise + 言語環境（Node.js + pnpm + Python + uv を mise で統一管理）
 # 5. Git セキュリティツール（gitleaks、mise に依存）
-# 6. コンテナツール（Dev Container開発の中核）
+# 6. コンテナ / サンドボックスツール（Dev Container開発の中核）
 # 7. クラウドツール（unzipに依存）
 # 8. AIエージェント CLI（Claude Code/Copilot CLIはcurlに依存、Codex/Gemini CLIはnpmに依存）
 # 9. AI パワーツール（markitdown は uv 依存、ast-grep/yq は mise 依存）
@@ -434,12 +436,21 @@ mise_use_global() {
   fi
 }
 
-# 6. コンテナツールのインストール
+# 6. コンテナ / サンドボックスツールのインストール
 install_container_tools() {
   [ "$INSTALL_CONTAINER" != "1" ] && return
 
   echo ""
-  echo "🐳 コンテナツールをインストール中..."
+  echo "🐳 コンテナ / サンドボックスツールをインストール中..."
+
+  # bubblewrap のインストール・アップデート
+  if ! command -v bwrap &>/dev/null; then
+    sudo apt-get install -y bubblewrap
+    echo "  ✅ bubblewrap インストール完了"
+  else
+    sudo apt-get install -y --only-upgrade bubblewrap >/dev/null 2>&1
+    echo "  ⏭️  bubblewrap は最新版です"
+  fi
 
   # Docker のインストール・アップデート
   if ! command -v docker &>/dev/null; then
@@ -473,7 +484,7 @@ install_container_tools() {
     echo "  ⏭️  既にdockerグループに所属しています"
   fi
 
-  echo "✅ コンテナツールインストール完了"
+  echo "✅ コンテナ / サンドボックスツールインストール完了"
 }
 
 # 7. クラウドツールのインストール
@@ -831,7 +842,7 @@ echo "  🔧 ビルドツール - build-essential"
 echo "  🔧 Git関連ツール - Git, GitHub CLI, gitleaks"
 echo "  📦 Node.js環境 - mise, Node.js LTS, pnpm"
 echo "  🐍 Python環境 - mise, Python, uv"
-echo "  🐳 コンテナツール - Docker Engine, Docker Compose"
+echo "  🐳 コンテナ / サンドボックスツール - Docker Engine, Docker Compose, bubblewrap"
 echo "  ☁️ クラウドツール - AWS CLI (default) / Azure CLI, Google Cloud CLI (opt-in)"
 echo "  🤖 AIエージェント CLI - Claude Code, Codex CLI, GitHub Copilot CLI, Gemini CLI"
 echo "  🧠 AIパワーツール - markitdown, tesseract-ocr, ffmpeg, ast-grep, yq"
@@ -883,8 +894,8 @@ if [[ ! $INSTALL_ALL =~ ^[Yy]?$ ]]; then
   echo ""
   [[ $REPLY =~ ^[Nn]$ ]] && INSTALL_PYTHON=0
 
-  # コンテナツール
-  _prompt_default_yes "🐳 コンテナツール (Docker, Docker Compose) をインストールしますか? [Y/n]: "
+  # コンテナ / サンドボックスツール
+  _prompt_default_yes "🐳 コンテナ / サンドボックスツール (Docker, Docker Compose, bubblewrap) をインストールしますか? [Y/n]: "
   echo ""
   [[ $REPLY =~ ^[Nn]$ ]] && INSTALL_CONTAINER=0
 
@@ -966,7 +977,7 @@ echo "🔧 Git ユーザー情報の確認..."
 if ! git config --global user.name &>/dev/null || [ -z "$(git config --global user.name)" ]; then
   echo ""
   echo "📝 Git ユーザー名が未設定です"
-  read -e -p "Git ユーザー名を入力してください（例: Taro Yamada）: " -i "$USER" git_user_name
+  read -r -e -p "Git ユーザー名を入力してください（例: Taro Yamada）: " -i "$USER" git_user_name
   echo "ℹ️  入力値: $git_user_name" # ログに記録
   # 空白文字のみの入力をチェック
   if [ -n "$git_user_name" ] && [ -n "${git_user_name// /}" ]; then
@@ -983,7 +994,7 @@ fi
 if ! git config --global user.email &>/dev/null || [ -z "$(git config --global user.email)" ]; then
   echo ""
   echo "📝 Git メールアドレスが未設定です"
-  read -e -p "Git メールアドレスを入力してください（例: your.email@example.com）: " git_user_email
+  read -r -e -p "Git メールアドレスを入力してください（例: your.email@example.com）: " git_user_email
   echo "ℹ️  入力値: $git_user_email" # ログに記録
   if [ -n "$git_user_email" ]; then
     # 基本的なメールアドレス形式のバリデーション
@@ -1170,7 +1181,7 @@ echo "✅ 依存パッケージインストール完了"
 # ========================================
 # 注意: 依存関係の順序で実行されます
 # 1. ビルド → 2. 基本CLI → 3. Git (git, gh) → 4. mise + 言語環境
-# → 5. Git セキュリティ (gitleaks) → 6. コンテナ → 7. クラウド → 8. AIエージェント
+# → 5. Git セキュリティ (gitleaks) → 6. コンテナ / サンドボックス → 7. クラウド → 8. AIエージェント
 # → 9. AI パワーツール → 10. 開発補助
 
 # 1. ビルドツールのインストール
@@ -1188,7 +1199,7 @@ install_mise_and_languages
 # 5. Git セキュリティツール（gitleaks、mise 経由）
 install_git_security_tools
 
-# 6. コンテナツールのインストール
+# 6. コンテナ / サンドボックスツールのインストール
 install_container_tools
 
 # 7. クラウドツールのインストール
@@ -1347,7 +1358,8 @@ echo "  🐍 Python エコシステム:"
 echo "    Python:         $(python3 --version 2>/dev/null || echo '未インストール')"
 echo "    uv:             $(uv --version 2>/dev/null | head -n1 || echo '未インストール')"
 echo ""
-echo "  🐳 コンテナツール:"
+echo "  🐳 コンテナ / サンドボックスツール:"
+echo "    bubblewrap:     $(bwrap --version 2>/dev/null || echo '未インストール')"
 echo "    Docker:         $(docker --version 2>/dev/null || echo '未インストール')"
 echo "    Docker Compose: $(docker compose version 2>/dev/null || echo '未インストール')"
 echo ""

--- a/tests/integration/assert-tools.sh
+++ b/tests/integration/assert-tools.sh
@@ -56,6 +56,12 @@ assert_tool "zoxide" zoxide --version
 assert_tool "shellcheck" shellcheck --version
 
 echo ""
+if [ "${INSTALL_CONTAINER:-1}" = "1" ]; then
+  echo "🐳 Container / sandbox"
+  assert_tool "bubblewrap" bwrap --version
+  echo ""
+fi
+
 echo "📌 Basic CLI"
 assert_tool "tree" tree --version
 assert_tool "fzf" fzf --version


### PR DESCRIPTION
## Summary

- Install bubblewrap with the Ubuntu/Debian container and sandbox tool set
- Show bubblewrap in install prompts, setup summary, docs, and verification commands
- Assert bwrap in integration checks when container tools are enabled

## Verification

- bash -n scripts/setup-local-ubuntu.sh tests/integration/assert-tools.sh
- mise exec -- shellcheck scripts/setup-local-ubuntu.sh tests/integration/assert-tools.sh
- mise exec -- markdownlint-cli2 --fix README.md README.ja.md CHANGELOG.md CHANGELOG.ja.md
- mise exec -- gitleaks detect --no-banner
- mise exec -- trivy fs --scanners vuln,secret --exit-code 1 --no-progress .
- CI=true mise exec -- bats tests/unit/shell-config.bats
- bash tests/smoke/run.sh

Note: pnpm run build/typecheck cannot run because this repo has no package.json.