### PR TITLE
ci: apply mise canonical pattern per handbook#84

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -25,6 +25,9 @@ jobs:
         with:
           cache: true
           github_token: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MISE_DISABLE_TOOLS: trivy
 
       - name: shellcheck
         run: |

--- a/.github/workflows/test-unit.yaml
+++ b/.github/workflows/test-unit.yaml
@@ -26,6 +26,9 @@ jobs:
         with:
           cache: true
           github_token: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MISE_DISABLE_TOOLS: trivy
 
       - name: Run BATS unit tests
         run: mise exec -- bats tests/unit/


### PR DESCRIPTION
## Summary

- `lint.yaml` と `test-unit.yaml` の `jdx/mise-action` ステップに `env: GITHUB_TOKEN` と `env: MISE_DISABLE_TOOLS: trivy` を追加し、handbook#84 / commons#76 で検証済みの **canonical pattern** に揃える。
- これにより mise が GitHub API を認証付きで呼び出せるようになり、rate limit / trivy 403 由来の chronic CI 失敗を解消する。
- bats unit テストは `git commit` を実行しないため、setup() への git identity 追加は不要（issue の AC #3 該当なし）。
- `gh` CLI も unit/smoke テストで使われないため、テストステップへの `GH_TOKEN` 注入も不要（AC #2 該当なし）。

## Affected files

- `.github/workflows/lint.yaml`
- `.github/workflows/test-unit.yaml`

`canary.yaml` / `test-integration.yaml` / `pr-check.yaml` / `labeler.yaml` / `sync-*.yaml` は `mise-action` を使っていないか、すでに別経路で `GITHUB_TOKEN` を渡しており対象外。

## Local verification

- `mise exec -- actionlint .github/workflows/{lint,test-unit}.yaml` — clean
- `mise exec -- lefthook run pre-commit` — yaml / trivy / gitleaks 全て pass
- bats unit は WSL ローカルで `/dev/tty` 起因の pre-existing 失敗があるが、本変更とは無関係（main でも同様に失敗）。CI 上では緑のはず。

## Test plan

- [ ] `lint` workflow green
- [ ] `test-unit` workflow green
- [ ] `--admin` bypass なしで merge できる

Closes #68
Refs handbook#84, commons#76