### PR TITLE
ci(infra): apply canonical pattern to CI workflows

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -23,6 +23,7 @@ jobs:
       - name: Set up mise
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
+          install: true
           cache: true
           github_token: ${{ secrets.GITHUB_TOKEN }}
         env:

--- a/.github/workflows/test-integration.yaml
+++ b/.github/workflows/test-integration.yaml
@@ -31,6 +31,16 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - name: Set up mise
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        with:
+          install: true
+          cache: true
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MISE_DISABLE_TOOLS: trivy
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 

--- a/.github/workflows/test-smoke.yaml
+++ b/.github/workflows/test-smoke.yaml
@@ -20,5 +20,16 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up mise
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        with:
+          install: true
+          cache: true
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MISE_DISABLE_TOOLS: trivy
+
       - name: Run smoke tests
         run: ./tests/smoke/run.sh

--- a/.github/workflows/test-unit.yaml
+++ b/.github/workflows/test-unit.yaml
@@ -24,6 +24,7 @@ jobs:
       - name: Set up mise (provides bats + linters)
         uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
         with:
+          install: true
           cache: true
           github_token: ${{ secrets.GITHUB_TOKEN }}
         env:

--- a/tests/unit/shell-config.bats
+++ b/tests/unit/shell-config.bats
@@ -12,6 +12,11 @@ setup() {
   SCRIPT_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
   # 実ホームを汚染しないよう tmpdir を HOME として使用
   export HOME="$BATS_TEST_TMPDIR"
+
+  # Git identity の設定 (canonical pattern)
+  git config --global user.email "test@example.com"
+  git config --global user.name "Test User"
+
   # setup-local-ubuntu.sh の上から関数定義部分までを source してロード
   # メイン処理（最下部の実行ブロック）を走らせないよう、関数定義セクションだけを抽出
   _script="$SCRIPT_ROOT/scripts/setup-local-ubuntu.sh"


### PR DESCRIPTION
Apply canonical pattern to .github/workflows/*.yaml and add git identity to BATS setup per handbook#84.

- Add 'install: true' to mise-action
- Ensure mise-action is present in all CI workflows (lint, test-unit, test-smoke, test-integration)
- Add git config to tests/unit/shell-config.bats setup

Fixes #68