### PR TITLE
chore(rename): generalize Linux setup scripts from ubuntu to linux

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -6,7 +6,7 @@
   - changed-files:
       - any-glob-to-any-file:
           - install.sh
-          - scripts/setup-local-ubuntu.sh
+          - scripts/setup-local-linux.sh
           - tests/integration/**
           - tests/smoke/**
           - .github/workflows/test-integration.yaml

--- a/.github/workflows/canary.yaml
+++ b/.github/workflows/canary.yaml
@@ -111,7 +111,7 @@ jobs:
             }
 
   # 新規: 非 WSL Linux（Ubuntu Server 等を想定した GitHub Actions の素の ubuntu-latest）
-  # で setup-local-ubuntu.sh を直接実行し、bare-metal インストールが緑であることを検証する。
+  # で setup-local-linux.sh を直接実行し、bare-metal インストールが緑であることを検証する。
   canary-ubuntu-native:
     name: Canary (Ubuntu Server, native install)
     runs-on: ubuntu-latest

--- a/CHANGELOG.ja.md
+++ b/CHANGELOG.ja.md
@@ -49,7 +49,7 @@
 
 ### 追加
 
-- Zsh環境セットアップスクリプト（`setup-zsh-ubuntu.sh`）
+- Zsh環境セットアップスクリプト（`setup-zsh-linux.sh`）
   - zsh本体のインストール
   - oh-my-zshフレームワークのインストール
   - zshプラグインのインストール
@@ -58,7 +58,7 @@
     - zsh-history-substring-search（履歴検索の強化）
     - zsh-syntax-highlighting（シンタックスハイライト）
   - デフォルトシェルの変更
-- WSL2/Ubuntu 環境セットアップスクリプト（`setup-local-ubuntu.sh`）
+- WSL2/Ubuntu 環境セットアップスクリプト（`setup-local-linux.sh`）
   - システム設定（Locale/Timezone、devcontainerマウント用ディレクトリ）
   - ビルドツール（build-essential）
   - 基本CLIツール（tree, fzf, jq, ripgrep, fd, unzip, wslu）

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Zsh環境セットアップスクリプト（`setup-zsh-ubuntu.sh`）
+- Zsh環境セットアップスクリプト（`setup-zsh-linux.sh`）
   - zsh本体のインストール
   - oh-my-zshフレームワークのインストール
   - zshプラグインのインストール
@@ -58,7 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - zsh-history-substring-search（履歴検索の強化）
     - zsh-syntax-highlighting（シンタックスハイライト）
   - デフォルトシェルの変更
-- WSL2/Ubuntu 環境セットアップスクリプト（`setup-local-ubuntu.sh`）
+- WSL2/Ubuntu 環境セットアップスクリプト（`setup-local-linux.sh`）
   - システム設定（Locale/Timezone、devcontainerマウント用ディレクトリ）
   - ビルドツール（build-essential）
   - 基本CLIツール（tree, fzf, jq, ripgrep, fd, unzip, wslu）

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,10 +1,10 @@
 # bootstrap
 
-**開発ホストを AI エージェント駆動開発向けにワンコマンド構築 — WSL2 / 非 WSL Ubuntu / macOS、Dev Container / 直接開発の両対応**
+**開発ホストを AI エージェント駆動開発向けにワンコマンド構築 — WSL2 / Linux (Ubuntu/Debian-based) / macOS、Dev Container / 直接開発の両対応**
 
 **[English](README.md) | 日本語**
 
-開発ホスト（WSL2 / 非 WSL の Ubuntu/Debian / macOS）を、モダンな AI エージェント駆動開発の前提が揃った状態にする包括的なセットアップスクリプト集です。**Dev Container 前提（推奨）**でも **直接ホストで開発**でも同じ基盤で動作します。AI エージェント CLI（Claude Code / Codex / Copilot / Gemini）と、エージェントが文書を読み・コードを検索し・構造化データを操作するための AI パワーツール（markitdown / ast-grep / yq / OCR / 音声処理）を標準搭載しています。
+開発ホスト（WSL2 / Linux (Ubuntu/Debian-based) / macOS）を、モダンな AI エージェント駆動開発の前提が揃った状態にする包括的なセットアップスクリプト集です。**Dev Container 前提（推奨）**でも **直接ホストで開発**でも同じ基盤で動作します。AI エージェント CLI（Claude Code / Codex / Copilot / Gemini）と、エージェントが文書を読み・コードを検索し・構造化データを操作するための AI パワーツール（markitdown / ast-grep / yq / OCR / 音声処理）を標準搭載しています。
 
 ## 目次
 
@@ -14,8 +14,8 @@
 - [4. クイックスタート](#4-クイックスタート)
 - [5. 前提条件](#5-前提条件)
 - [6. スクリプト](#6-スクリプト)
-  - [6.1 setup-zsh-ubuntu.sh](#61-setup-zsh-ubuntush)
-  - [6.2 setup-local-ubuntu.sh](#62-setup-local-ubuntush)
+  - [6.1 setup-zsh-linux.sh](#61-setup-zsh-linuxsh)
+  - [6.2 setup-local-linux.sh](#62-setup-local-linuxsh)
   - [6.3 setup-local-macos.sh](#63-setup-local-macossh)
   - [6.4 update-tools.sh](#64-update-toolssh)
 - [7. トラブルシューティング](#7-トラブルシューティング)
@@ -24,7 +24,7 @@
 
 ## 1. リポジトリ背景
 
-- **Dev Container / 直接開発の両方**に対応した、開発ホスト初期化の単一ソース（WSL2 / 非 WSL の Ubuntu/Debian / macOS）。
+- **Dev Container / 直接開発の両方**に対応した、開発ホスト初期化の単一ソース（WSL2 / Linux (Ubuntu/Debian-based) / macOS）。
 - **AI ファースト**: AI エージェント CLI と AI パワーツール（文書変換 / OCR / 構造的コード検索 / YAML / 音声処理）を一級カテゴリとして提供。
 - **mise** を中核にランタイム・CLI ツールを統一管理、Python パッケージは **uv**、Node は Corepack 互換の **pnpm**。
 - 冪等性・詳細ログ・2026 年時点のアクティブなデフォルト（gitleaks / markitdown / ast-grep 等）を重視。
@@ -38,9 +38,9 @@ bootstrap/
 ├── README.md
 ├── README.ja.md
 └── scripts/
-    ├── setup-local-ubuntu.sh       # Ubuntu/Debian（WSL2 + 非 WSL Linux）の包括セットアップ
+    ├── setup-local-linux.sh       # Ubuntu/Debian（WSL2 + 非 WSL Linux）の包括セットアップ
     ├── setup-local-macos.sh        # macOS（mise を入口にした軽量フロー）
-    ├── setup-zsh-ubuntu.sh         # zsh + oh-my-zsh（Ubuntu/Debian）
+    ├── setup-zsh-linux.sh         # zsh + oh-my-zsh（Ubuntu/Debian）
     └── update-tools.sh             # クロス OS の一括更新
 ```
 
@@ -104,14 +104,14 @@ cd bootstrap
 
 | OS | スクリプト | 状態 |
 |---|---|---|
-| **WSL2 / Ubuntu 22.04 LTS** | `setup-local-ubuntu.sh` | ✅ 全 PR / main push で CI 検証 |
-| **WSL2 / Ubuntu 24.04 LTS** | `setup-local-ubuntu.sh` | ✅ 全 PR / main push で CI 検証 |
-| **非 WSL Linux（Ubuntu Server 等）** | `setup-local-ubuntu.sh` | ✅ 週次 canary で `ubuntu-latest` 上の bare-metal インストールを検証 |
+| **WSL2 / Ubuntu 22.04 LTS** | `setup-local-linux.sh` | ✅ 全 PR / main push で CI 検証 |
+| **WSL2 / Ubuntu 24.04 LTS** | `setup-local-linux.sh` | ✅ 全 PR / main push で CI 検証 |
+| **非 WSL Linux（Ubuntu Server 等）** | `setup-local-linux.sh` | ✅ 週次 canary で `ubuntu-latest` 上の bare-metal インストールを検証 |
 | **macOS（latest）** | `setup-local-macos.sh` | ✅ 週次 canary で `macos-latest` を検証（mise を入口にした軽量フロー） |
-| **Ubuntu 25.10 (Questing Quokka)** | `setup-local-ubuntu.sh` | ✅ 週次 canary（`ubuntu:rolling` Docker タグ） |
-| **Ubuntu 26.04 LTS (Resolute Raccoon)** | `setup-local-ubuntu.sh` | ✅ 週次 canary（`ubuntu:devel` Docker タグ） — 次期 LTS 切替直後から動作 |
+| **Ubuntu 25.10 (Questing Quokka)** | `setup-local-linux.sh` | ✅ 週次 canary（`ubuntu:rolling` Docker タグ） |
+| **Ubuntu 26.04 LTS (Resolute Raccoon)** | `setup-local-linux.sh` | ✅ 週次 canary（`ubuntu:devel` Docker タグ） — 次期 LTS 切替直後から動作 |
 
-`install.sh` は OS を自動判定し `local` を適切なスクリプト（Linux → `setup-local-ubuntu.sh`、Darwin → `setup-local-macos.sh`）に dispatch します。週次 Canary は `ubuntu:devel` / `ubuntu:rolling` Docker タグ・素の `ubuntu-latest` ランナー（非 WSL Linux）・`macos-latest` の 3 系統で統合 harness を回し、上流破壊的変更を全サポート OS で早期検知します。
+`install.sh` は OS を自動判定し `local` を適切なスクリプト（Linux → `setup-local-linux.sh`、Darwin → `setup-local-macos.sh`）に dispatch します。週次 Canary は `ubuntu:devel` / `ubuntu:rolling` Docker タグ・素の `ubuntu-latest` ランナー（非 WSL Linux）・`macos-latest` の 3 系統で統合 harness を回し、上流破壊的変更を全サポート OS で早期検知します。
 
 ### 5.2 Dev Container ワークフロー（推奨）
 
@@ -129,11 +129,11 @@ cd bootstrap
 
 ## 6. スクリプト
 
-### 6.1 setup-zsh-ubuntu.sh
+### 6.1 setup-zsh-linux.sh
 
 Ubuntu/Debian 環境（WSL2 + 非 WSL Linux）で zsh + oh-my-zsh + プラグインをセットアップするスクリプトです。macOS では本ステップは自動的にスキップされ、`install.sh zsh` は通知だけ出して正常終了します（macOS は zsh が標準シェル）。
 
-`install.sh` 経由でも、`scripts/setup-zsh-ubuntu.sh` を直接実行しても使えます。
+`install.sh` 経由でも、`scripts/setup-zsh-linux.sh` を直接実行しても使えます。
 
 **6.1.1 インストールされる内容**
 
@@ -172,7 +172,7 @@ curl -fsSL https://raw.githubusercontent.com/ozzy-labs/bootstrap/main/install.sh
 ./install.sh zsh
 
 # スクリプトを直接実行
-./scripts/setup-zsh-ubuntu.sh
+./scripts/setup-zsh-linux.sh
 
 # ログを記録する場合
 SETUP_LOG=1 ./install.sh zsh
@@ -207,11 +207,11 @@ echo $plugins
 
 ---
 
-### 6.2 setup-local-ubuntu.sh
+### 6.2 setup-local-linux.sh
 
 Ubuntu/Debian 環境（WSL2 + 非 WSL Linux：Ubuntu Server / EC2 / GCE / コンテナ系 VM 等）に必要な開発ツールをインストールする包括的なセットアップスクリプトです。WSL2 専用の `wslu` / `BROWSER=wslview` は意図的に**自動化対象から外し**、必要な場合の手動コマンドはスクリプト内コメントに記載しています。
 
-`install.sh` 経由でも、`scripts/setup-local-ubuntu.sh` を直接実行しても使えます。
+`install.sh` 経由でも、`scripts/setup-local-linux.sh` を直接実行しても使えます。
 
 **6.2.1 インストールされるツール**
 
@@ -296,9 +296,9 @@ curl -fsSL https://raw.githubusercontent.com/ozzy-labs/bootstrap/main/install.sh
 ./install.sh local
 
 # スクリプトを直接実行
-./scripts/setup-local-ubuntu.sh
+./scripts/setup-local-linux.sh
 
-# ログを記録する場合（デフォルトパス: ~/setup-local-ubuntu-YYYYMMDD-HHMMSS.log）
+# ログを記録する場合（デフォルトパス: ~/setup-local-linux-YYYYMMDD-HHMMSS.log）
 SETUP_LOG=1 ./install.sh local
 
 # カスタムログファイルパスを指定
@@ -445,7 +445,7 @@ exit
 `SETUP_LOG` 環境変数を設定すると、すべての出力がログファイルに記録されます：
 
 ```bash
-# デフォルトパスに記録（~/setup-local-ubuntu-YYYYMMDD-HHMMSS.log）
+# デフォルトパスに記録（~/setup-local-linux-YYYYMMDD-HHMMSS.log）
 SETUP_LOG=1 ./install.sh local
 
 # カスタムパスに記録
@@ -473,7 +473,7 @@ SETUP_LOG=/tmp/setup.log ./install.sh local
 
 ### 6.3 setup-local-macos.sh
 
-`setup-local-ubuntu.sh` の macOS 版。意図的に軽量化しており、**mise を入口にした共通フロー**でランタイム/CLI を導入します。OS 統合（Docker Desktop、認証 UI が必要な AI エージェント CLI、クラウド CLI）は手動セットアップに任せます。
+`setup-local-linux.sh` の macOS 版。意図的に軽量化しており、**mise を入口にした共通フロー**でランタイム/CLI を導入します。OS 統合（Docker Desktop、認証 UI が必要な AI エージェント CLI、クラウド CLI）は手動セットアップに任せます。
 
 **6.3.1 インストールされるツール**
 
@@ -545,7 +545,7 @@ SETUP_LOG=/tmp/update.log ./install.sh update
 
 - 冪等性: 未インストールツールは `⏭️` でスキップ
 - 耐障害性: 個別コマンドの失敗は警告表示のみで、全体処理は継続
-- ログ対応: `setup-local-ubuntu.sh` と同じ `SETUP_LOG` 規約に従う
+- ログ対応: `setup-local-linux.sh` と同じ `SETUP_LOG` 規約に従う
 - クロス OS: Linux（WSL2 / 非 WSL）と macOS で同等に動作
 
 ---

--- a/README.ja.md
+++ b/README.ja.md
@@ -102,14 +102,14 @@ cd bootstrap
 
 ### 5.1 サポート対象 OS
 
-| OS | スクリプト | 状態 |
+| OS / ディストリビューション | スクリプト | 状態 |
 |---|---|---|
-| **WSL2 / Ubuntu 22.04 LTS** | `setup-local-linux.sh` | ✅ 全 PR / main push で CI 検証 |
-| **WSL2 / Ubuntu 24.04 LTS** | `setup-local-linux.sh` | ✅ 全 PR / main push で CI 検証 |
-| **非 WSL Linux（Ubuntu Server 等）** | `setup-local-linux.sh` | ✅ 週次 canary で `ubuntu-latest` 上の bare-metal インストールを検証 |
-| **macOS（latest）** | `setup-local-macos.sh` | ✅ 週次 canary で `macos-latest` を検証（mise を入口にした軽量フロー） |
-| **Ubuntu 25.10 (Questing Quokka)** | `setup-local-linux.sh` | ✅ 週次 canary（`ubuntu:rolling` Docker タグ） |
-| **Ubuntu 26.04 LTS (Resolute Raccoon)** | `setup-local-linux.sh` | ✅ 週次 canary（`ubuntu:devel` Docker タグ） — 次期 LTS 切替直後から動作 |
+| **Linux (Ubuntu 22.04 LTS)** | \`setup-local-linux.sh\` | ✅ 全 PR / main push で CI 検証 |
+| **Linux (Ubuntu 24.04 LTS)** | \`setup-local-linux.sh\` | ✅ 全 PR / main push で CI 検証 |
+| **Linux (Ubuntu Server 等)** | \`setup-local-linux.sh\` | ✅ 週次 canary で \`ubuntu-latest\` 上の bare-metal インストールを検証 |
+| **macOS (latest)** | \`setup-local-macos.sh\` | ✅ 週次 canary で \`macos-latest\` を検証（mise を入口にした軽量フロー） |
+| **Linux (Ubuntu 25.10)** | \`setup-local-linux.sh\` | ✅ 週次 canary（\`ubuntu:rolling\` Docker タグ） |
+| **Linux (Ubuntu 26.04 LTS)** | \`setup-local-linux.sh\` | ✅ 週次 canary（\`ubuntu:devel\` Docker タグ） — 次期 LTS 切替直後から動作 |
 
 `install.sh` は OS を自動判定し `local` を適切なスクリプト（Linux → `setup-local-linux.sh`、Darwin → `setup-local-macos.sh`）に dispatch します。週次 Canary は `ubuntu:devel` / `ubuntu:rolling` Docker タグ・素の `ubuntu-latest` ランナー（非 WSL Linux）・`macos-latest` の 3 系統で統合 harness を回し、上流破壊的変更を全サポート OS で早期検知します。
 

--- a/README.md
+++ b/README.md
@@ -102,14 +102,14 @@ These scripts are designed to set up a **development host** across multiple oper
 
 ### 5.1 Supported operating systems
 
-| OS | Script | Status |
+| OS / Distribution | Script | Status |
 |---|---|---|
-| **WSL2 / Ubuntu 22.04 LTS** | `setup-local-linux.sh` | ✅ CI-verified every PR / main push |
-| **WSL2 / Ubuntu 24.04 LTS** | `setup-local-linux.sh` | ✅ CI-verified every PR / main push |
-| **Non-WSL Linux (Ubuntu Server etc.)** | `setup-local-linux.sh` | ✅ Canary-verified weekly on `ubuntu-latest` (bare-metal install, no Docker) |
+| **Linux (Ubuntu 22.04 LTS)** | `setup-local-linux.sh` | ✅ CI-verified every PR / main push |
+| **Linux (Ubuntu 24.04 LTS)** | `setup-local-linux.sh` | ✅ CI-verified every PR / main push |
+| **Linux (Ubuntu Server etc.)** | `setup-local-linux.sh` | ✅ Canary-verified weekly on `ubuntu-latest` (bare-metal install, no Docker) |
 | **macOS (latest)** | `setup-local-macos.sh` | ✅ Canary-verified weekly on `macos-latest` (mise-first lightweight flow) |
-| **Ubuntu 25.10 (Questing Quokka)** | `setup-local-linux.sh` | ✅ Canary-verified weekly via `ubuntu:rolling` Docker tag |
-| **Ubuntu 26.04 LTS (Resolute Raccoon)** | `setup-local-linux.sh` | ✅ Canary-verified weekly via `ubuntu:devel` — ready for the next LTS the day it lands |
+| **Linux (Ubuntu 25.10)** | `setup-local-linux.sh` | ✅ Canary-verified weekly via `ubuntu:rolling` Docker tag |
+| **Linux (Ubuntu 26.04 LTS)** | `setup-local-linux.sh` | ✅ Canary-verified weekly via `ubuntu:devel` — ready for the next LTS the day it lands |
 
 `install.sh` auto-detects the OS and dispatches `local` to the matching script (`setup-local-linux.sh` for Linux, `setup-local-macos.sh` for Darwin). The weekly canary runs the full integration harness against `ubuntu:devel` / `ubuntu:rolling` Docker tags, the bare `ubuntu-latest` runner (non-WSL Linux), and `macos-latest`, so upstream breaking changes are caught early on every supported platform.
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # bootstrap
 
-**One-shot host setup for AI-agent-driven development — WSL2 / non-WSL Ubuntu / macOS, Dev Container or direct host use**
+**One-shot host setup for AI-agent-driven development — WSL2 / Linux (Ubuntu/Debian-based) / macOS, Dev Container or direct host use**
 
 **English | [日本語](README.ja.md)**
 
-A comprehensive collection of shell scripts that bootstraps a development host (WSL2, non-WSL Ubuntu/Debian, or macOS) with everything needed for modern, AI-agent-driven development. Works equally well whether you develop **inside Dev Containers** (recommended) or **directly on the host**. Ships AI agent CLIs (Claude Code / Codex / Copilot / Gemini) alongside a curated set of AI power tools (markitdown, ast-grep, yq, OCR/audio backends) so agents can read documents, search code, and operate on structured data out of the box.
+A comprehensive collection of shell scripts that bootstraps a development host (WSL2, Linux (Ubuntu/Debian-based), or macOS) with everything needed for modern, AI-agent-driven development. Works equally well whether you develop **inside Dev Containers** (recommended) or **directly on the host**. Ships AI agent CLIs (Claude Code / Codex / Copilot / Gemini) alongside a curated set of AI power tools (markitdown, ast-grep, yq, OCR/audio backends) so agents can read documents, search code, and operate on structured data out of the box.
 
 ## Table of Contents
 
@@ -14,8 +14,8 @@ A comprehensive collection of shell scripts that bootstraps a development host (
 - [4. Quick Start](#4-quick-start)
 - [5. Prerequisites](#5-prerequisites)
 - [6. Scripts](#6-scripts)
-  - [6.1 setup-zsh-ubuntu.sh](#61-setup-zsh-ubuntush)
-  - [6.2 setup-local-ubuntu.sh](#62-setup-local-ubuntush)
+  - [6.1 setup-zsh-linux.sh](#61-setup-zsh-linuxsh)
+  - [6.2 setup-local-linux.sh](#62-setup-local-linuxsh)
   - [6.3 setup-local-macos.sh](#63-setup-local-macossh)
   - [6.4 update-tools.sh](#64-update-toolssh)
 - [7. Troubleshooting](#7-troubleshooting)
@@ -24,7 +24,7 @@ A comprehensive collection of shell scripts that bootstraps a development host (
 
 ## 1. Repository Background
 
-- Provides a single source of truth for development-host provisioning (WSL2, non-WSL Ubuntu/Debian, macOS) that works for **both Dev Container and direct-host workflows**.
+- Provides a single source of truth for development-host provisioning (WSL2, Linux (Ubuntu/Debian-based), macOS) that works for **both Dev Container and direct-host workflows**.
 - **AI-first**: AI agent CLIs and AI power tools (document conversion, OCR, structural code search, YAML/audio processing) are promoted to first-class install categories.
 - Standardized on **mise** as the unified runtime/CLI version manager, with **uv** handling Python packages and **Corepack-compatible pnpm** for Node.
 - Emphasizes idempotent execution, detailed diagnostics, and actively maintained 2026-era defaults.
@@ -34,13 +34,13 @@ A comprehensive collection of shell scripts that bootstraps a development host (
 
 ```
 bootstrap/
-├── install.sh                      # OS-aware dispatcher (Linux → ubuntu, Darwin → macos)
+├── install.sh                      # OS-aware dispatcher (Linux → linux, Darwin → macos)
 ├── README.md
 ├── README.ja.md
 └── scripts/
-    ├── setup-local-ubuntu.sh       # Ubuntu/Debian (WSL2 + non-WSL Linux) full provisioning
+    ├── setup-local-linux.sh        # Linux (Ubuntu/Debian-based) full provisioning
     ├── setup-local-macos.sh        # macOS (mise-first, lightweight)
-    ├── setup-zsh-ubuntu.sh         # zsh + oh-my-zsh on Ubuntu/Debian
+    ├── setup-zsh-linux.sh          # zsh + oh-my-zsh on Linux (Ubuntu/Debian-based)
     └── update-tools.sh             # Cross-OS batch update
 ```
 
@@ -53,9 +53,9 @@ bootstrap/
 - 🐍 **Python Ecosystem** - mise-managed Python + uv for packages/venvs/CLI tools
 - ☁️ **Cloud CLIs** - AWS CLI v2 (default) / Azure CLI, Google Cloud CLI (opt-in)
 - 🔒 **Modern Secret Scanning** - gitleaks (2026 de-facto, actively maintained); pair with lefthook per project
-- 🎨 **Shell Experience** - zsh + oh-my-zsh + plugins (Ubuntu/Debian), fzf / ripgrep / fd / jq / tree
+- 🎨 **Shell Experience** - zsh + oh-my-zsh + plugins (Linux), fzf / ripgrep / fd / jq / tree
 - 🔄 **One-shot Upgrades** - `install.sh update` batch-refreshes mise/uv/npm-managed tools
-- 🐧 **Ubuntu LTS Coverage** - CI-verified on 22.04 + 24.04; canary-tested on **26.04 Resolute Raccoon** (next LTS) so the toolchain continues to work the day 26.04 lands on WSL2
+- 🐧 **Linux (Ubuntu/Debian-based) LTS Coverage** - CI-verified on 22.04 + 24.04; canary-tested on **26.04 Resolute Raccoon** (next LTS) so the toolchain continues to work the day 26.04 lands on WSL2
 - 🍎 **macOS Coverage** - Native `setup-local-macos.sh` keeps the same mise-first flow; canary-verified weekly on `macos-latest`
 - 🖥️ **Non-WSL Linux Coverage** - Bare-metal install verified weekly on `ubuntu-latest` (Ubuntu Server, EC2, GCE, etc.)
 - ✅ **Idempotency** - Safe to run multiple times
@@ -104,14 +104,14 @@ These scripts are designed to set up a **development host** across multiple oper
 
 | OS | Script | Status |
 |---|---|---|
-| **WSL2 / Ubuntu 22.04 LTS** | `setup-local-ubuntu.sh` | ✅ CI-verified every PR / main push |
-| **WSL2 / Ubuntu 24.04 LTS** | `setup-local-ubuntu.sh` | ✅ CI-verified every PR / main push |
-| **Non-WSL Linux (Ubuntu Server etc.)** | `setup-local-ubuntu.sh` | ✅ Canary-verified weekly on `ubuntu-latest` (bare-metal install, no Docker) |
+| **WSL2 / Ubuntu 22.04 LTS** | `setup-local-linux.sh` | ✅ CI-verified every PR / main push |
+| **WSL2 / Ubuntu 24.04 LTS** | `setup-local-linux.sh` | ✅ CI-verified every PR / main push |
+| **Non-WSL Linux (Ubuntu Server etc.)** | `setup-local-linux.sh` | ✅ Canary-verified weekly on `ubuntu-latest` (bare-metal install, no Docker) |
 | **macOS (latest)** | `setup-local-macos.sh` | ✅ Canary-verified weekly on `macos-latest` (mise-first lightweight flow) |
-| **Ubuntu 25.10 (Questing Quokka)** | `setup-local-ubuntu.sh` | ✅ Canary-verified weekly via `ubuntu:rolling` Docker tag |
-| **Ubuntu 26.04 LTS (Resolute Raccoon)** | `setup-local-ubuntu.sh` | ✅ Canary-verified weekly via `ubuntu:devel` — ready for the next LTS the day it lands |
+| **Ubuntu 25.10 (Questing Quokka)** | `setup-local-linux.sh` | ✅ Canary-verified weekly via `ubuntu:rolling` Docker tag |
+| **Ubuntu 26.04 LTS (Resolute Raccoon)** | `setup-local-linux.sh` | ✅ Canary-verified weekly via `ubuntu:devel` — ready for the next LTS the day it lands |
 
-`install.sh` auto-detects the OS and dispatches `local` to the matching script (`setup-local-ubuntu.sh` for Linux, `setup-local-macos.sh` for Darwin). The weekly canary runs the full integration harness against `ubuntu:devel` / `ubuntu:rolling` Docker tags, the bare `ubuntu-latest` runner (non-WSL Linux), and `macos-latest`, so upstream breaking changes are caught early on every supported platform.
+`install.sh` auto-detects the OS and dispatches `local` to the matching script (`setup-local-linux.sh` for Linux, `setup-local-macos.sh` for Darwin). The weekly canary runs the full integration harness against `ubuntu:devel` / `ubuntu:rolling` Docker tags, the bare `ubuntu-latest` runner (non-WSL Linux), and `macos-latest`, so upstream breaking changes are caught early on every supported platform.
 
 ### 5.2 Dev Container workflow (recommended)
 
@@ -129,11 +129,11 @@ Both workflows share the same foundation (`mise` + `uv` + Docker) so you can mov
 
 ## 6. Scripts
 
-### 6.1 setup-zsh-ubuntu.sh
+### 6.1 setup-zsh-linux.sh
 
 Sets up zsh + oh-my-zsh + plugins on Ubuntu/Debian (WSL2 + non-WSL Linux). On macOS this step is skipped — `install.sh zsh` prints a notice and exits cleanly because macOS already ships with zsh as the default shell.
 
-You can run it either through `install.sh` or directly via `scripts/setup-zsh-ubuntu.sh`.
+You can run it either through `install.sh` or directly via `scripts/setup-zsh-linux.sh`.
 
 **6.1.1 What Gets Installed**
 
@@ -172,7 +172,7 @@ curl -fsSL https://raw.githubusercontent.com/ozzy-labs/bootstrap/main/install.sh
 ./install.sh zsh
 
 # Direct script execution
-./scripts/setup-zsh-ubuntu.sh
+./scripts/setup-zsh-linux.sh
 
 # With logging
 SETUP_LOG=1 ./install.sh zsh
@@ -207,11 +207,11 @@ echo $plugins
 
 ---
 
-### 6.2 setup-local-ubuntu.sh
+### 6.2 setup-local-linux.sh
 
 Comprehensive setup script that installs required development tools on Ubuntu/Debian (WSL2 + non-WSL Linux such as Ubuntu Server, EC2, GCE, container-based VMs, etc.). WSL-specific bits (`wslu`, `BROWSER=wslview`) are intentionally **not** automated — see the inline notes in the script for the manual one-liner.
 
-You can run it either through `install.sh` or directly via `scripts/setup-local-ubuntu.sh`.
+You can run it either through `install.sh` or directly via `scripts/setup-local-linux.sh`.
 
 **6.2.1 Installed Tools**
 
@@ -296,9 +296,9 @@ curl -fsSL https://raw.githubusercontent.com/ozzy-labs/bootstrap/main/install.sh
 ./install.sh local
 
 # Direct script execution
-./scripts/setup-local-ubuntu.sh
+./scripts/setup-local-linux.sh
 
-# With logging (default path: ~/setup-local-ubuntu-YYYYMMDD-HHMMSS.log)
+# With logging (default path: ~/setup-local-linux-YYYYMMDD-HHMMSS.log)
 SETUP_LOG=1 ./install.sh local
 
 # Specify custom log file path
@@ -445,7 +445,7 @@ All critical operations include error checking with detailed information in a un
 Setting the `SETUP_LOG` environment variable records all output to a log file:
 
 ```bash
-# Record to default path (~/setup-local-ubuntu-YYYYMMDD-HHMMSS.log)
+# Record to default path (~/setup-local-linux-YYYYMMDD-HHMMSS.log)
 SETUP_LOG=1 ./install.sh local
 
 # Record to custom path
@@ -473,7 +473,7 @@ Logs include:
 
 ### 6.3 setup-local-macos.sh
 
-macOS counterpart to `setup-local-ubuntu.sh`, intentionally lighter-weight: focuses on **mise as the entry point** for runtime/CLI provisioning, and defers OS-integration (Docker Desktop, AI agent CLIs requiring interactive auth, cloud CLIs) to manual install.
+macOS counterpart to `setup-local-linux.sh`, intentionally lighter-weight: focuses on **mise as the entry point** for runtime/CLI provisioning, and defers OS-integration (Docker Desktop, AI agent CLIs requiring interactive auth, cloud CLIs) to manual install.
 
 **6.3.1 What Gets Installed**
 
@@ -545,7 +545,7 @@ SETUP_LOG=/tmp/update.log ./install.sh update
 
 - Idempotent — missing tools are skipped with an `⏭️` marker
 - Resilient — a single command failure emits a warning but does not abort the run
-- Log-friendly — honors the same `SETUP_LOG` convention as `setup-local-ubuntu.sh`
+- Log-friendly — honors the same `SETUP_LOG` convention as `setup-local-linux.sh`
 - Cross-OS — works equally on Linux (WSL2 / non-WSL) and macOS
 
 ---

--- a/install.sh
+++ b/install.sh
@@ -23,9 +23,9 @@ Usage:
   curl -fsSL https://raw.githubusercontent.com/ozzy-labs/bootstrap/main/install.sh | bash -s -- [zsh|local|all|update] [--ref <git-ref>]
 
 Commands:
-  zsh     Run scripts/setup-zsh-ubuntu.sh (Linux/WSL only; macOS skips with a notice)
+  zsh     Run scripts/setup-zsh-linux.sh (Linux/WSL only; macOS skips with a notice)
   local   Run the host setup script for the detected OS
-            - Linux  → scripts/setup-local-ubuntu.sh
+            - Linux  → scripts/setup-local-linux.sh
             - macOS  → scripts/setup-local-macos.sh
   all     Run zsh setup (when supported) + local setup in order (default)
   update  Run scripts/update-tools.sh (batch-update mise/uv/npm managed tools)
@@ -82,7 +82,7 @@ local_setup_script_for_os() {
   local os
   os="$(detect_os)"
   case "$os" in
-  linux) printf '%s/scripts/setup-local-ubuntu.sh' "$base_dir" ;;
+  linux) printf '%s/scripts/setup-local-linux.sh' "$base_dir" ;;
   darwin) printf '%s/scripts/setup-local-macos.sh' "$base_dir" ;;
   *) die "Unsupported OS: $(uname -s) (only Linux and macOS are supported)" ;;
   esac
@@ -94,10 +94,10 @@ run_zsh_setup_if_supported() {
   os="$(detect_os)"
   if [ "$os" = "darwin" ]; then
     log ""
-    log "ℹ️  Skipping setup-zsh-ubuntu.sh on macOS (use the system zsh; oh-my-zsh can be installed manually if desired)."
+    log "ℹ️  Skipping setup-zsh-linux.sh on macOS (use the system zsh; oh-my-zsh can be installed manually if desired)."
     return 0
   fi
-  run_script "$base_dir/scripts/setup-zsh-ubuntu.sh"
+  run_script "$base_dir/scripts/setup-zsh-linux.sh"
 }
 
 run_local() {

--- a/scripts/setup-local-linux.sh
+++ b/scripts/setup-local-linux.sh
@@ -787,7 +787,7 @@ install_docker_engine_and_compose() {
 if [ -n "$SETUP_LOG" ]; then
   # SETUP_LOG=1 または SETUP_LOG=true の場合はデフォルトパスを使用
   if [ "$SETUP_LOG" = "1" ] || [ "$SETUP_LOG" = "true" ]; then
-    LOG_FILE="$HOME/setup-local-ubuntu-$(date +%Y%m%d-%H%M%S).log"
+    LOG_FILE="$HOME/setup-local-linux-$(date +%Y%m%d-%H%M%S).log"
   else
     LOG_FILE="$SETUP_LOG"
   fi
@@ -798,7 +798,7 @@ if [ -n "$SETUP_LOG" ]; then
   echo "ℹ️  ログを $LOG_FILE に記録します"
 fi
 
-echo "🚀 Ubuntu/Debian ローカル環境セットアップ開始（WSL2 / 非 WSL の両対応）"
+echo "🚀 Linux (Ubuntu/Debian-based) ローカル環境セットアップ開始"
 echo ""
 
 # ========================================
@@ -813,7 +813,7 @@ fi
 
 # Ubuntu/Debian系ディストリビューションのチェック
 if ! grep -qi "ubuntu\|debian" /etc/os-release 2>/dev/null; then
-  echo "⚠️  このスクリプトは Ubuntu/Debian 系ディストリビューション用です"
+  echo "⚠️  このスクリプトは Ubuntu/Debian 系ディストリビューション専用です"
   echo "ℹ️  現在の OS: $(grep PRETTY_NAME /etc/os-release | cut -d'"' -f2)"
   _prompt_default_no "続行しますか？ (y/N): "
   echo

--- a/scripts/setup-local-linux.sh
+++ b/scripts/setup-local-linux.sh
@@ -813,7 +813,7 @@ fi
 
 # Ubuntu/Debian系ディストリビューションのチェック
 if ! grep -qi "ubuntu\|debian" /etc/os-release 2>/dev/null; then
-  echo "⚠️  このスクリプトは Ubuntu/Debian 系ディストリビューション専用です"
+  echo "⚠️  このスクリプトは Ubuntu/Debian 系向けに最適化されています。他 OS では動作保証外です。"
   echo "ℹ️  現在の OS: $(grep PRETTY_NAME /etc/os-release | cut -d'"' -f2)"
   _prompt_default_no "続行しますか？ (y/N): "
   echo

--- a/scripts/setup-local-macos.sh
+++ b/scripts/setup-local-macos.sh
@@ -5,7 +5,7 @@ set -e
 # ========================================
 # macOS ローカル環境セットアップスクリプト
 # ----------------------------------------
-# Phase 1 Wave 1: setup-local-ubuntu.sh と同じく mise を入口にした
+# Phase 1 Wave 1: setup-local-linux.sh と同じく mise を入口にした
 # 共通フローで開発環境を整える。Linux 側との重複を最小化するため、
 # OS 固有の依存（Homebrew、apt の代替）以外はすべて mise / uv tool に集約する。
 #
@@ -234,7 +234,7 @@ echo ""
 # 1. 環境チェック
 if [ "$(uname -s)" != "Darwin" ]; then
   echo "⚠️  このスクリプトは macOS 専用です（現在の OS: $(uname -s)）"
-  echo "ℹ️  Linux 環境では scripts/setup-local-ubuntu.sh を使用してください"
+  echo "ℹ️  Linux 環境では scripts/setup-local-linux.sh を使用してください"
   exit 1
 fi
 

--- a/scripts/setup-zsh-linux.sh
+++ b/scripts/setup-zsh-linux.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-# Ubuntu/Debian系 zsh + oh-my-zsh + プラグインセットアップスクリプト
+# Linux (Ubuntu/Debian-based) zsh + oh-my-zsh + プラグインセットアップスクリプト
 
 # ========================================
 # グローバル変数（インストール対象フラグ）
@@ -281,7 +281,7 @@ change_default_shell() {
 if [ -n "$SETUP_LOG" ]; then
   # SETUP_LOG=1 または SETUP_LOG=true の場合はデフォルトパスを使用
   if [ "$SETUP_LOG" = "1" ] || [ "$SETUP_LOG" = "true" ]; then
-    LOG_FILE="$HOME/setup-zsh-ubuntu-$(date +%Y%m%d-%H%M%S).log"
+    LOG_FILE="$HOME/setup-zsh-linux-$(date +%Y%m%d-%H%M%S).log"
   else
     LOG_FILE="$SETUP_LOG"
   fi
@@ -292,7 +292,7 @@ if [ -n "$SETUP_LOG" ]; then
   echo "ℹ️  ログを $LOG_FILE に記録します"
 fi
 
-echo "🚀 zsh + oh-my-zsh セットアップ開始"
+echo "🚀 Linux (Ubuntu/Debian-based) zsh + oh-my-zsh セットアップ開始"
 echo ""
 
 # ========================================
@@ -307,7 +307,7 @@ fi
 
 # Ubuntu/Debian系ディストリビューションのチェック
 if ! grep -qi "ubuntu\|debian" /etc/os-release 2>/dev/null; then
-  echo "⚠️  このスクリプトは Ubuntu/Debian 系ディストリビューション用です"
+  echo "⚠️  このスクリプトは Ubuntu/Debian 系ディストリビューション専用です"
   echo "ℹ️  現在の OS: $(grep PRETTY_NAME /etc/os-release | cut -d'"' -f2)"
   _prompt_default_no "続行しますか？ (y/N): "
   echo "ℹ️  ユーザー入力: $REPLY" # ログに記録
@@ -467,7 +467,7 @@ echo "1. ターミナルを完全に閉じて再ログイン:"
 echo "   exit"
 echo ""
 echo "2. 開発環境のセットアップを実行:"
-echo "   ./scripts/setup-local-ubuntu.sh"
+echo "   ./scripts/setup-local-linux.sh"
 echo ""
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 echo ""

--- a/scripts/setup-zsh-linux.sh
+++ b/scripts/setup-zsh-linux.sh
@@ -307,7 +307,7 @@ fi
 
 # Ubuntu/Debian系ディストリビューションのチェック
 if ! grep -qi "ubuntu\|debian" /etc/os-release 2>/dev/null; then
-  echo "⚠️  このスクリプトは Ubuntu/Debian 系ディストリビューション専用です"
+  echo "⚠️  このスクリプトは Ubuntu/Debian 系向けに最適化されています。他 OS では動作保証外です。"
   echo "ℹ️  現在の OS: $(grep PRETTY_NAME /etc/os-release | cut -d'"' -f2)"
   _prompt_default_no "続行しますか？ (y/N): "
   echo "ℹ️  ユーザー入力: $REPLY" # ログに記録

--- a/scripts/update-tools.sh
+++ b/scripts/update-tools.sh
@@ -3,7 +3,7 @@
 # update-tools.sh
 # -----------------------------------------------------------------------
 # mise / uv tool / npm グローバル経由で導入済みツールを一括更新する。
-# setup-local-ubuntu.sh のハイブリッドメンテ方針を踏襲:
+# setup-local-linux.sh のハイブリッドメンテ方針を踏襲:
 #   - mise: mise self-update + mise upgrade
 #   - uv tool: uv tool upgrade --all（markitdown 等）
 #   - npm global: AI エージェント CLI（Codex / Gemini）

--- a/tests/integration/Dockerfile
+++ b/tests/integration/Dockerfile
@@ -16,7 +16,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
     CI=true
 
 # 最小限の前提パッケージ: スクリプトが自力でインストールする前段として必要
-# - git: Git 設定の事前構成のため（最新版は setup-local-ubuntu.sh が PPA から入れ直す）
+# - git: Git 設定の事前構成のため（最新版は setup-local-linux.sh が PPA から入れ直す）
 # - gnupg: add-apt-repository が PPA の GPG 鍵をインポートする際に gpg-agent を必要とする。
 #   ubuntu:22.04 の minimal イメージには未同梱のため明示的に追加する。
 RUN apt-get update \
@@ -42,7 +42,7 @@ COPY --chown=testuser:testuser . /workspace
 
 USER testuser
 
-# Git の最低限の設定（setup-local-ubuntu.sh の Git 設定プロンプトを回避）
+# Git の最低限の設定（setup-local-linux.sh の Git 設定プロンプトを回避）
 RUN git config --global user.name "Test User" \
     && git config --global user.email "test@example.com"
 

--- a/tests/integration/entrypoint.sh
+++ b/tests/integration/entrypoint.sh
@@ -86,7 +86,7 @@ printf '━━━━━━━━━━━━━━━━━━━━━━━━
 # pipe 経由の実行を明示的に踏ませて回帰を防ぐ:
 #   1. install.sh の EXIT trap が `local tmp_dir` を遅延展開し、
 #      set -u 下で unbound variable で死ぬ
-#   2. setup-zsh-ubuntu.sh の `read -p` が pipe 越し EOF + set -e で
+#   2. setup-zsh-linux.sh の `read -p` が pipe 越し EOF + set -e で
 #      入力プロンプト到達と同時に終了する
 
 # --- 1. install.sh の EXIT trap が pipe 経由でも安全に発火することを確認 ---
@@ -103,35 +103,35 @@ if grep -qE "unbound variable" "$PIPE_INSTALL_LOG"; then
 fi
 echo "✅ install.sh EXIT trap is safe under pipe execution"
 
-# --- 2. setup-zsh-ubuntu.sh が pipe 経由でも完走することを確認 ---
+# --- 2. setup-zsh-linux.sh が pipe 経由でも完走することを確認 ---
 # CI=true により非対話モードで実行され、対話プロンプトはすべて既定値で
 # 自動回答される。read -p が EOF で失敗していれば set -e で即死する。
 PIPE_ZSH_LOG="/tmp/pipe-zsh.log"
-if ! cat /workspace/scripts/setup-zsh-ubuntu.sh | bash >"$PIPE_ZSH_LOG" 2>&1; then
-  echo "❌ setup-zsh-ubuntu.sh failed under pipe execution. Log:"
+if ! cat /workspace/scripts/setup-zsh-linux.sh | bash >"$PIPE_ZSH_LOG" 2>&1; then
+  echo "❌ setup-zsh-linux.sh failed under pipe execution. Log:"
   cat "$PIPE_ZSH_LOG"
   exit 1
 fi
 if grep -qE "unbound variable" "$PIPE_ZSH_LOG"; then
-  echo "❌ setup-zsh-ubuntu.sh emitted 'unbound variable' under pipe execution"
+  echo "❌ setup-zsh-linux.sh emitted 'unbound variable' under pipe execution"
   exit 1
 fi
-echo "✅ setup-zsh-ubuntu.sh completes under pipe execution"
+echo "✅ setup-zsh-linux.sh completes under pipe execution"
 
-# --- 3. setup-local-ubuntu.sh が pipe 経由でも完走することを確認 ---
+# --- 3. setup-local-linux.sh が pipe 経由でも完走することを確認 ---
 # CI=true により非対話モードで実行される。pipe 経由実行で stdin が EOF で
 # あっても、/dev/tty フォールバックまたは _is_non_interactive 分岐により
 # プロンプトが安全に処理されることを確認する。
 PIPE_LOCAL_LOG="/tmp/pipe-local.log"
-if ! cat /workspace/scripts/setup-local-ubuntu.sh | bash >"$PIPE_LOCAL_LOG" 2>&1; then
-  echo "❌ setup-local-ubuntu.sh failed under pipe execution. Log tail:"
+if ! cat /workspace/scripts/setup-local-linux.sh | bash >"$PIPE_LOCAL_LOG" 2>&1; then
+  echo "❌ setup-local-linux.sh failed under pipe execution. Log tail:"
   tail -50 "$PIPE_LOCAL_LOG"
   exit 1
 fi
 if grep -qE "unbound variable" "$PIPE_LOCAL_LOG"; then
-  echo "❌ setup-local-ubuntu.sh emitted 'unbound variable' under pipe execution"
+  echo "❌ setup-local-linux.sh emitted 'unbound variable' under pipe execution"
   exit 1
 fi
-echo "✅ setup-local-ubuntu.sh completes under pipe execution"
+echo "✅ setup-local-linux.sh completes under pipe execution"
 
 printf '\n✅ Integration test passed (both runs completed, no shell config duplication, pipe-mode OK)\n'

--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -8,7 +8,7 @@
 #   ./tests/integration/run.sh                 # デフォルト (24.04)
 #   ./tests/integration/run.sh 22.04           # 単一バージョン
 #   ./tests/integration/run.sh 22.04 24.04     # 複数バージョン逐次
-#   ./tests/integration/run.sh devel           # Canary（次期 Ubuntu）
+#   ./tests/integration/run.sh devel           # Canary（次期 Linux リリース）
 # =======================================================================
 set -e
 

--- a/tests/smoke/run.sh
+++ b/tests/smoke/run.sh
@@ -131,14 +131,11 @@ assert_failure "update-tools.sh rejects unknown flag" \
 assert_success "install.sh syntax check" \
   bash -n install.sh
 
-assert_success "setup-local-ubuntu.sh syntax check" \
-  bash -n scripts/setup-local-ubuntu.sh
+assert_success "setup-local-linux.sh syntax check" \
+  bash -n scripts/setup-local-linux.sh
 
-assert_success "setup-local-macos.sh syntax check" \
-  bash -n scripts/setup-local-macos.sh
-
-assert_success "setup-zsh-ubuntu.sh syntax check" \
-  bash -n scripts/setup-zsh-ubuntu.sh
+assert_success "setup-zsh-linux.sh syntax check" \
+  bash -n scripts/setup-zsh-linux.sh
 
 assert_success "update-tools.sh syntax check" \
   bash -n scripts/update-tools.sh

--- a/tests/unit/shell-config.bats
+++ b/tests/unit/shell-config.bats
@@ -2,7 +2,7 @@
 # =======================================================================
 # tests/unit/shell-config.bats
 # -----------------------------------------------------------------------
-# setup-local-ubuntu.sh 内の add_to_shell_config 関数の冪等性・パターン
+# setup-local-linux.sh 内の add_to_shell_config 関数の冪等性・パターン
 # 検出・エッジケースを検証する。
 #
 # HOME を BATS_TEST_TMPDIR に差し替えて実ホームディレクトリを汚染しない。
@@ -17,9 +17,9 @@ setup() {
   git config --global user.email "test@example.com"
   git config --global user.name "Test User"
 
-  # setup-local-ubuntu.sh の上から関数定義部分までを source してロード
+  # setup-local-linux.sh の上から関数定義部分までを source してロード
   # メイン処理（最下部の実行ブロック）を走らせないよう、関数定義セクションだけを抽出
-  _script="$SCRIPT_ROOT/scripts/setup-local-ubuntu.sh"
+  _script="$SCRIPT_ROOT/scripts/setup-local-linux.sh"
   # 関数定義 & ヘルパーがある範囲を抽出（先頭から「メイン処理開始」コメントまで）
   _extracted="$BATS_TEST_TMPDIR/functions.sh"
   awk '/^# メイン処理開始/ {exit} {print}' "$_script" >"$_extracted"


### PR DESCRIPTION
## 概要
Linux セットアップスクリプトを Ubuntu 固有名から汎用的な名称に変更し、OSチェックを強化しました。

## 変更内容
- `scripts/setup-local-ubuntu.sh` → `scripts/setup-local-linux.sh`
- `scripts/setup-zsh-ubuntu.sh` → `scripts/setup-zsh-linux.sh`
- 各スクリプトの冒頭に Debian/Ubuntu 系であることを確認するガードを追加
- `install.sh` および CI 設定、README 内の参照をすべて更新
- ユニットテスト (`bats`) でのパスを確認済み