### PR TITLE
feat(doctor): add doctor subcommand for environment diagnostics

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -19,8 +19,8 @@ detect_os() {
 usage() {
   cat <<'EOF'
 Usage:
-  ./install.sh [zsh|local|all|update] [--ref <git-ref>] [--auto|--interactive]
-  curl -fsSL https://raw.githubusercontent.com/ozzy-labs/bootstrap/main/install.sh | bash -s -- [zsh|local|all|update] [--ref <git-ref>] [--auto|--interactive]
+  ./install.sh [zsh|local|all|update|doctor] [--ref <git-ref>] [--auto|--interactive]
+  curl -fsSL https://raw.githubusercontent.com/ozzy-labs/bootstrap/main/install.sh | bash -s -- [zsh|local|all|update|doctor] [--ref <git-ref>] [--auto|--interactive]
 
 Commands:
   zsh     Run scripts/setup-zsh-linux.sh (Linux/WSL only; macOS skips with a notice)
@@ -29,6 +29,7 @@ Commands:
             - macOS  → scripts/setup-local-macos.sh
   all     Run zsh setup (when supported) + local setup in order (default)
   update  Run scripts/update-tools.sh (batch-update mise/uv/npm managed tools)
+  doctor  Run scripts/doctor.sh (diagnose environment integrity, exit 0/1/2)
 
 Options:
   --ref <git-ref>  Download scripts from the specified branch, tag, or commit
@@ -120,6 +121,9 @@ run_local() {
   update)
     run_script "$base_dir/scripts/update-tools.sh"
     ;;
+  doctor)
+    run_script "$base_dir/scripts/doctor.sh"
+    ;;
   *)
     die "Unknown command: $target"
     ;;
@@ -132,7 +136,7 @@ main() {
 
   while [ "$#" -gt 0 ]; do
     case "$1" in
-    zsh | local | all | update)
+    zsh | local | all | update | doctor)
       target="$1"
       ;;
     --ref)

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+# scripts/doctor.sh
+# 開発環境の整合性を診断し、問題があれば修復ヒントを提示する。
+#
+# Exit code:
+#   0 = 健全（warn / error なし）
+#   1 = 警告あり（推奨ツール未インストール、軽微な drift 等）
+#   2 = エラーあり（必須ツール欠落、修復が必要）
+#
+# Usage:
+#   ./install.sh doctor          # 通常実行
+#   ./scripts/doctor.sh          # 直接実行も可
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# shellcheck source=lib/detect.sh
+. "$SCRIPT_DIR/lib/detect.sh"
+# shellcheck source=lib/prompts.sh
+. "$SCRIPT_DIR/lib/prompts.sh"
+# shellcheck source=lib/shell_config.sh
+. "$SCRIPT_DIR/lib/shell_config.sh"
+# shellcheck source=lib/apt.sh
+. "$SCRIPT_DIR/lib/apt.sh"
+# shellcheck source=lib/mise.sh
+. "$SCRIPT_DIR/lib/mise.sh"
+# shellcheck source=lib/doctor-checks.sh
+. "$SCRIPT_DIR/lib/doctor-checks.sh"
+
+# Doctor は読み取り専用の診断であり対話プロンプトを伴わない。
+# tty fallback は不要なので呼び出さない。
+
+# ========================================
+# 結果集計バケット
+# ========================================
+# 各エントリは "STATUS|CATEGORY|MESSAGE|FIX_HINT" 形式
+# FIX_HINT は省略可
+_DOCTOR_RESULTS=()
+
+# 結果を記録するヘルパー
+# $1: status (ok / warn / error)
+# $2: category (system-tools / mise / chezmoi 等)
+# $3: message
+# $4: fix_hint（省略可）
+doctor_record() {
+  local status="$1"
+  local category="$2"
+  local message="$3"
+  local fix_hint="${4:-}"
+  _DOCTOR_RESULTS+=("$status|$category|$message|$fix_hint")
+}
+
+# ========================================
+# 診断実行
+# ========================================
+
+echo "🩺 bootstrap doctor を実行中..."
+echo ""
+
+check_system_tools
+check_mise
+check_mise_managed_tools
+check_chezmoi_drift
+check_zshrc_d
+
+# ========================================
+# 結果表示と集計
+# ========================================
+
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "📊 診断結果"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+
+ok_count=0
+warn_count=0
+error_count=0
+fix_hints=()
+
+for result in "${_DOCTOR_RESULTS[@]}"; do
+  IFS='|' read -r status category message fix_hint <<<"$result"
+  case "$status" in
+  ok)
+    icon="✅"
+    ok_count=$((ok_count + 1))
+    ;;
+  warn)
+    icon="⚠️ "
+    warn_count=$((warn_count + 1))
+    ;;
+  error)
+    icon="❌"
+    error_count=$((error_count + 1))
+    ;;
+  *)
+    icon="?"
+    ;;
+  esac
+  printf '%s [%s] %s\n' "$icon" "$category" "$message"
+  if [ -n "$fix_hint" ] && [ "$status" != "ok" ]; then
+    printf '   ↳ 対処: %s\n' "$fix_hint"
+    fix_hints+=("$fix_hint")
+  fi
+done
+
+echo ""
+printf 'サマリー: ✅ %d  ⚠️  %d  ❌ %d\n' "$ok_count" "$warn_count" "$error_count"
+echo ""
+
+# ========================================
+# 終了処理
+# ========================================
+
+if [ "$error_count" -gt 0 ]; then
+  echo "❌ エラーがあります。上記の対処コマンドを実行してから再度 doctor を実行してください。"
+  exit 2
+elif [ "$warn_count" -gt 0 ]; then
+  echo "⚠️  警告があります。必要に応じて対処コマンドを実行してください。"
+  exit 1
+else
+  echo "🎉 環境は健全です。"
+  exit 0
+fi

--- a/scripts/lib/doctor-checks.sh
+++ b/scripts/lib/doctor-checks.sh
@@ -1,0 +1,139 @@
+#!/bin/bash
+# shellcheck disable=SC2088  # チルダはログメッセージ内の表示用であり、パス展開は不要
+# scripts/lib/doctor-checks.sh
+# Doctor サブコマンドが行う各診断ロジック。
+# 各 check_* 関数は doctor_record 関数を呼んで結果を集計バケットに追記する。
+# 前提: lib/detect.sh, lib/mise.sh が事前に source されていること。
+# 前提: SCRIPT_DIR が定義されていること（リポジトリ内 dotfiles の解決用）。
+
+# 1. システム基本ツールの検証
+# bootstrap が動くために最低限必要な CLI が揃っているかをチェック
+check_system_tools() {
+  local tools=(curl git unzip xz tar)
+  local tool
+  for tool in "${tools[@]}"; do
+    if command -v "$tool" &>/dev/null; then
+      doctor_record ok "system-tools" "$tool: 利用可能"
+    else
+      local fix
+      if _is_ubuntu_or_debian; then
+        case "$tool" in
+        xz) fix="sudo apt-get install -y xz-utils" ;;
+        *) fix="sudo apt-get install -y $tool" ;;
+        esac
+      else
+        fix="brew install $tool"
+      fi
+      doctor_record error "system-tools" "$tool が見つかりません" "$fix"
+    fi
+  done
+}
+
+# 2. mise の存在確認と PATH 設定の検証
+check_mise() {
+  if [ -x "$MISE_BIN" ]; then
+    local mise_version
+    mise_version=$("$MISE_BIN" --version 2>/dev/null | head -n1)
+    doctor_record ok "mise" "mise が利用可能 ($mise_version)"
+
+    # PATH に ~/.local/bin と shims ディレクトリが含まれるか
+    if [[ ":$PATH:" == *":$HOME/.local/bin:"* ]]; then
+      doctor_record ok "mise" "PATH に ~/.local/bin が含まれている"
+    else
+      doctor_record warn "mise" "PATH に ~/.local/bin が含まれていない（シェル再起動で反映される可能性あり）" \
+        'export PATH="$HOME/.local/bin:$PATH"'
+    fi
+
+    if [[ ":$PATH:" == *":$HOME/.local/share/mise/shims:"* ]]; then
+      doctor_record ok "mise" "PATH に mise shims が含まれている"
+    else
+      doctor_record warn "mise" "PATH に mise shims が含まれていない（mise activate が必要）" \
+        'eval "$(mise activate bash)"  # または zsh'
+    fi
+  else
+    doctor_record error "mise" "mise が未インストール ($MISE_BIN にバイナリなし)" \
+      "curl -fsSL https://mise.run | sh"
+  fi
+}
+
+# 3. mise 管理下の主要ツール（Node.js / pnpm / Python / uv）の整合性
+check_mise_managed_tools() {
+  if ! [ -x "$MISE_BIN" ]; then
+    # mise 自体が無いため check_mise の方で error 報告済み。スキップ。
+    return 0
+  fi
+
+  local expected=(node pnpm python uv)
+  local managed_list
+  managed_list=$(_mise_at_home ls --global 2>/dev/null | awk '{print $1}')
+
+  local tool
+  for tool in "${expected[@]}"; do
+    if printf '%s\n' "$managed_list" | grep -qx "$tool"; then
+      local installed_version
+      installed_version=$(_mise_at_home current "$tool" 2>/dev/null || echo "?")
+      doctor_record ok "mise-tools" "$tool は mise 管理下 (current: $installed_version)"
+    else
+      local recommended
+      case "$tool" in
+      node) recommended="node@lts" ;;
+      pnpm) recommended="pnpm@latest" ;;
+      python) recommended="python@latest" ;;
+      uv) recommended="uv@latest" ;;
+      *) recommended="$tool@latest" ;;
+      esac
+      doctor_record warn "mise-tools" "$tool が mise で管理されていない" \
+        "mise use --global $recommended"
+    fi
+  done
+}
+
+# 4. chezmoi 管理下のドットファイルの drift 検出
+check_chezmoi_drift() {
+  if ! command -v chezmoi &>/dev/null; then
+    doctor_record warn "chezmoi" "chezmoi が未インストール（drift 検出スキップ）" \
+      "mise use --global chezmoi@latest"
+    return 0
+  fi
+
+  # SCRIPT_DIR は scripts/ ディレクトリ。1 つ上がリポジトリルート。
+  local repo_root
+  repo_root="$(cd "$SCRIPT_DIR/.." && pwd)"
+  if [ ! -d "$repo_root/dotfiles" ]; then
+    doctor_record warn "chezmoi" "リポジトリ内に dotfiles/ がない（drift 検出スキップ）"
+    return 0
+  fi
+
+  # chezmoi diff: drift がなければ空文字。エラーは無視する。
+  local diff_output
+  diff_output=$(chezmoi diff --source "$repo_root/dotfiles" 2>/dev/null || true)
+  if [ -z "$diff_output" ]; then
+    doctor_record ok "chezmoi" "ドットファイルに drift なし (source: $repo_root/dotfiles)"
+  else
+    local diff_lines
+    diff_lines=$(printf '%s\n' "$diff_output" | wc -l)
+    doctor_record warn "chezmoi" "ドットファイルに drift あり ($diff_lines 行の差分)" \
+      "chezmoi apply --source $repo_root/dotfiles"
+  fi
+}
+
+# 5. ~/.zshrc.d/ の読み込み設定の存在確認
+check_zshrc_d() {
+  if [ ! -d "$HOME/.zshrc.d" ]; then
+    doctor_record warn "zshrc.d" "~/.zshrc.d/ ディレクトリが存在しない" \
+      "mkdir -p ~/.zshrc.d"
+    return 0
+  fi
+
+  if [ ! -f "$HOME/.zshrc" ]; then
+    doctor_record warn "zshrc.d" "~/.zshrc が存在しない（zsh を使用していない場合は問題なし）"
+    return 0
+  fi
+
+  if grep -q "zshrc.d" "$HOME/.zshrc"; then
+    doctor_record ok "zshrc.d" "~/.zshrc.d/ の読み込み設定が ~/.zshrc に存在"
+  else
+    doctor_record warn "zshrc.d" "~/.zshrc.d/ の読み込み設定が ~/.zshrc に未追加" \
+      "./install.sh local  # または手動で .zshrc に追加"
+  fi
+}

--- a/scripts/lib/prompts.sh
+++ b/scripts/lib/prompts.sh
@@ -37,8 +37,12 @@ _prompt_default_no() {
 # stdin が tty でなく /dev/tty が読める場合は /dev/tty にフォールバックする。
 # 非対話モード（CI / ASSUME_YES）ではフォールバックしない。
 # 呼び出し側スクリプト先頭で `_attach_tty_if_needed` を呼ぶ。
+#
+# /dev/tty が device file として存在するが open に失敗するケース（一部の
+# コンテナ / サブシェル）でもスクリプト全体を落とさないよう、exec の失敗を
+# 黙って受け流す。
 _attach_tty_if_needed() {
   if [ ! -t 0 ] && [ -r /dev/tty ] && ! _is_non_interactive; then
-    exec </dev/tty
+    exec </dev/tty 2>/dev/null || true
   fi
 }

--- a/tests/smoke/run.sh
+++ b/tests/smoke/run.sh
@@ -87,7 +87,7 @@ assert_stdout_contains "install.sh --help prints Usage" \
   bash install.sh --help
 
 assert_stdout_contains "install.sh --help lists subcommands" \
-  "zsh|local|all|update" \
+  "zsh|local|all|update|doctor" \
   bash install.sh --help
 
 assert_failure "install.sh rejects unknown flag" \
@@ -139,6 +139,9 @@ assert_success "setup-zsh-linux.sh syntax check" \
 
 assert_success "update-tools.sh syntax check" \
   bash -n scripts/update-tools.sh
+
+assert_success "doctor.sh syntax check" \
+  bash -n scripts/doctor.sh
 
 # ------------------------------------------------------------------
 # サマリー

--- a/tests/unit/doctor-checks.bats
+++ b/tests/unit/doctor-checks.bats
@@ -1,0 +1,194 @@
+#!/usr/bin/env bats
+# =======================================================================
+# tests/unit/doctor-checks.bats
+# -----------------------------------------------------------------------
+# scripts/lib/doctor-checks.sh の各 check_* 関数を検証する。
+# system / mise / chezmoi をモックして、結果バケット _DOCTOR_RESULTS の
+# 内容で判定する。
+# =======================================================================
+
+setup() {
+  SCRIPT_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+  export SCRIPT_DIR="$SCRIPT_ROOT/scripts"
+
+  # 実ホームを汚染しない
+  export HOME="$BATS_TEST_TMPDIR"
+  export PATH="$BATS_TEST_TMPDIR/bin:$PATH"
+  mkdir -p "$BATS_TEST_TMPDIR/bin"
+
+  # 必要 lib を source
+  # shellcheck disable=SC1091
+  source "$SCRIPT_ROOT/scripts/lib/detect.sh"
+  # shellcheck disable=SC1091
+  source "$SCRIPT_ROOT/scripts/lib/shell_config.sh"
+  # shellcheck disable=SC1091
+  source "$SCRIPT_ROOT/scripts/lib/mise.sh"
+  # shellcheck disable=SC1091
+  source "$SCRIPT_ROOT/scripts/lib/doctor-checks.sh"
+
+  # 結果バケットと doctor_record をテスト用に定義
+  _DOCTOR_RESULTS=()
+  doctor_record() {
+    _DOCTOR_RESULTS+=("$1|$2|$3|${4:-}")
+  }
+  export -f doctor_record
+
+  # MISE_BIN をテスト用 tmpdir に向ける（実ホストの mise を見ない）
+  export MISE_BIN="$BATS_TEST_TMPDIR/mise"
+}
+
+# 結果配列から特定 status のエントリ数をカウント
+_count_status() {
+  local target="$1"
+  local count=0
+  local entry
+  for entry in "${_DOCTOR_RESULTS[@]}"; do
+    [[ "$entry" == "$target|"* ]] && count=$((count + 1))
+  done
+  printf '%d\n' "$count"
+}
+
+# 結果配列に特定 category のエントリが特定 status で存在するか
+_has_status_for_category() {
+  local status="$1"
+  local category="$2"
+  local entry
+  for entry in "${_DOCTOR_RESULTS[@]}"; do
+    [[ "$entry" == "$status|$category|"* ]] && return 0
+  done
+  return 1
+}
+
+# ------------------------------------------------------------------
+# check_system_tools
+# ------------------------------------------------------------------
+
+@test "check_system_tools: records ok for tools that exist on host (curl, git)" {
+  # curl と git は CI 含めほぼ常に存在する想定
+  check_system_tools
+  _has_status_for_category "ok" "system-tools"
+}
+
+@test "check_system_tools: records error with fix hint for missing tool" {
+  # サブシェルで PATH を変更し、teardown が rm 等を呼べる環境を保つ
+  mkdir -p "$BATS_TEST_TMPDIR/empty-bin"
+  local results
+  results=$(
+    PATH="$BATS_TEST_TMPDIR/empty-bin"
+    _DOCTOR_RESULTS=()
+    check_system_tools
+    printf '%s\n' "${_DOCTOR_RESULTS[@]}"
+  )
+
+  # error が複数件出るはず（curl/git/unzip/xz/tar すべて欠落）
+  local error_count
+  error_count=$(printf '%s\n' "$results" | grep -c "^error|system-tools|" || true)
+  [ "$error_count" -ge 1 ]
+
+  # fix_hint に apt-get または brew が含まれるはず
+  printf '%s\n' "$results" | grep -qE "(apt-get|brew)"
+}
+
+# ------------------------------------------------------------------
+# check_mise
+# ------------------------------------------------------------------
+
+@test "check_mise: records error when mise binary is missing" {
+  # MISE_BIN を存在しないパスに
+  export MISE_BIN="$BATS_TEST_TMPDIR/nonexistent-mise"
+  check_mise
+  _has_status_for_category "error" "mise"
+}
+
+@test "check_mise: records ok when mise binary exists" {
+  # ダミーの mise バイナリを作成
+  cat >"$MISE_BIN" <<'EOF'
+#!/bin/bash
+echo "2026.4.1 macos-arm64 (2026-04-01)"
+EOF
+  chmod +x "$MISE_BIN"
+
+  check_mise
+  _has_status_for_category "ok" "mise"
+}
+
+# ------------------------------------------------------------------
+# check_mise_managed_tools
+# ------------------------------------------------------------------
+
+@test "check_mise_managed_tools: skips silently when mise is not installed" {
+  # MISE_BIN は存在しない
+  export MISE_BIN="$BATS_TEST_TMPDIR/nonexistent-mise"
+  _DOCTOR_RESULTS=()
+  check_mise_managed_tools
+
+  # 何も記録されないことを確認
+  [ "${#_DOCTOR_RESULTS[@]}" -eq 0 ]
+}
+
+@test "check_mise_managed_tools: records warn for tools not under mise" {
+  # ダミーの mise バイナリ。`ls --global` で何も出さない（管理下に何もない）
+  cat >"$MISE_BIN" <<'EOF'
+#!/bin/bash
+case "$1" in
+  ls) ;;  # empty output
+  current) ;;
+esac
+EOF
+  chmod +x "$MISE_BIN"
+
+  check_mise_managed_tools
+
+  # node / pnpm / python / uv が warn として記録される
+  _has_status_for_category "warn" "mise-tools"
+  # 4 つすべて warn
+  [ "$(_count_status warn)" -eq 4 ]
+}
+
+# ------------------------------------------------------------------
+# check_zshrc_d
+# ------------------------------------------------------------------
+
+@test "check_zshrc_d: records warn when ~/.zshrc.d/ does not exist" {
+  # HOME は BATS_TEST_TMPDIR で .zshrc.d は無い
+  check_zshrc_d
+  _has_status_for_category "warn" "zshrc.d"
+}
+
+@test "check_zshrc_d: records ok when ~/.zshrc has zshrc.d sourcing" {
+  mkdir -p "$HOME/.zshrc.d"
+  cat >"$HOME/.zshrc" <<'EOF'
+if [ -d ~/.zshrc.d ]; then
+  for file in ~/.zshrc.d/*.zsh; do
+    [ -r "$file" ] && source "$file"
+  done
+fi
+EOF
+  check_zshrc_d
+  _has_status_for_category "ok" "zshrc.d"
+}
+
+@test "check_zshrc_d: records warn when ~/.zshrc.d/ exists but ~/.zshrc lacks sourcing" {
+  mkdir -p "$HOME/.zshrc.d"
+  # NOTE: コメント文字列に "zshrc.d" を含めない（grep が誤検知するため）
+  echo "# basic zshrc without sourcing logic" >"$HOME/.zshrc"
+  check_zshrc_d
+  _has_status_for_category "warn" "zshrc.d"
+}
+
+# ------------------------------------------------------------------
+# check_chezmoi_drift
+# ------------------------------------------------------------------
+
+@test "check_chezmoi_drift: records warn when chezmoi is not installed" {
+  # サブシェルで PATH を変更し teardown を保護
+  mkdir -p "$BATS_TEST_TMPDIR/empty-bin"
+  local results
+  results=$(
+    PATH="$BATS_TEST_TMPDIR/empty-bin"
+    _DOCTOR_RESULTS=()
+    check_chezmoi_drift
+    printf '%s\n' "${_DOCTOR_RESULTS[@]}"
+  )
+  printf '%s\n' "$results" | grep -q "^warn|chezmoi|"
+}


### PR DESCRIPTION
## Summary

- `./install.sh doctor`（または `scripts/doctor.sh` 直接実行）で開発環境の整合性を診断
- システム必須ツール / mise / mise 管理ツール / chezmoi drift / ~/.zshrc.d/ をチェック
- exit code で健全度を 3 段階表現（0=ok, 1=warn, 2=error）
- 各 warn / error には OS 判別 (apt / brew) に応じた fix hint を併記
- bats 10 件追加で各 check_* をモック検証

Closes #84

## 設計方針

- #88 の lib/* を全面再利用: detect.sh / mise.sh / shell_config.sh を source。モジュール分割の意義をここで実証
- 読み取り専用: 既定では診断のみで自動修復しない。fix hint はコピペ可能な形式で提供
- OS 別 fix hint: `_is_ubuntu_or_debian` で判別し、apt-get / brew コマンドを切り替え
- exit code 階層: 0 / 1 / 2 で CI ジョブのフェイル粒度を制御可能

## 副次的修正

`_attach_tty_if_needed` を堅牢化: `/dev/tty` open に失敗してもスクリプトが落ちないよう exec 失敗を黙って受け流す。

## Test plan

- [x] bats 36/36 通過（既存 26 + 新規 10）
- [x] smoke 14/14 通過（doctor.sh syntax 含む）
- [x] shellcheck / shfmt クリーン
- [x] 実機での `bash install.sh doctor` で exit code 1 伝播確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)