### PR TITLE
docs(readme): publish-readiness — TLS hardening, SHA256 verification, doctor section

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -2,9 +2,18 @@
 
 **開発ホストを AI エージェント駆動開発向けにワンコマンド構築 — WSL2 / Linux (Ubuntu/Debian-based) / macOS、Dev Container / 直接開発の両対応**
 
+[![Lint](https://github.com/ozzy-labs/bootstrap/actions/workflows/lint.yaml/badge.svg)](https://github.com/ozzy-labs/bootstrap/actions/workflows/lint.yaml)
+[![Unit](https://github.com/ozzy-labs/bootstrap/actions/workflows/test-unit.yaml/badge.svg)](https://github.com/ozzy-labs/bootstrap/actions/workflows/test-unit.yaml)
+[![Smoke](https://github.com/ozzy-labs/bootstrap/actions/workflows/test-smoke.yaml/badge.svg)](https://github.com/ozzy-labs/bootstrap/actions/workflows/test-smoke.yaml)
+[![Integration](https://github.com/ozzy-labs/bootstrap/actions/workflows/test-integration.yaml/badge.svg)](https://github.com/ozzy-labs/bootstrap/actions/workflows/test-integration.yaml)
+[![License: MIT](https://img.shields.io/github/license/ozzy-labs/bootstrap)](LICENSE)
+[![Latest Release](https://img.shields.io/github/v/release/ozzy-labs/bootstrap?include_prereleases&label=release)](https://github.com/ozzy-labs/bootstrap/releases/latest)
+
 **[English](README.md) | 日本語**
 
 開発ホスト（WSL2 / Linux (Ubuntu/Debian-based) / macOS）を、モダンな AI エージェント駆動開発の前提が揃った状態にする包括的なセットアップスクリプト集です。**Dev Container 前提（推奨）**でも **直接ホストで開発**でも同じ基盤で動作します。AI エージェント CLI（Claude Code / Codex / Copilot / Gemini）と、エージェントが文書を読み・コードを検索し・構造化データを操作するための AI パワーツール（markitdown / ast-grep / yq / OCR / 音声処理）を標準搭載しています。
+
+> **なぜ Bash + `curl | bash` なのか?** 本プロジェクトは意識的に **Node.js / npm / コンパイル済みバイナリに依存しない単一の Bash スクリプト** として配布しています。ランタイムを *インストールする* ツールがランタイムを *要求する* のは設計上不自然だからです。トレードオフ（リッチな TUI を持たない）と引き換えに得られるのは、**まっさらなマシンで初日から動くワンライナーインストール** という強い資産。詳しい意思決定は [ADR-0004](./docs/adr/ADR-0004-stay-bash-and-publish-readiness.md) を参照。
 
 ## 目次
 
@@ -18,6 +27,7 @@
   - [6.2 setup-local-linux.sh](#62-setup-local-linuxsh)
   - [6.3 setup-local-macos.sh](#63-setup-local-macossh)
   - [6.4 update-tools.sh](#64-update-toolssh)
+  - [6.5 doctor.sh](#65-doctorsh)
 - [7. トラブルシューティング](#7-トラブルシューティング)
 - [8. コントリビューション](#8-コントリビューション)
 - [9. 変更履歴](#9-変更履歴)
@@ -64,16 +74,20 @@ bootstrap/
 
 ## 4. クイックスタート
 
+> **推奨呼び出し** には `--proto '=https' --tlsv1.2` を付けて TLS バージョンを明示的に固定します。これにより HTTP へのリダイレクトや TLS 1.1 以下のフォールバックを拒否できます（`rustup` / `mise` と同じパターン）。
+
 ```bash
 # 1. zsh セットアップ（推奨：最初に実行）
-curl -fsSL https://raw.githubusercontent.com/ozzy-labs/bootstrap/main/install.sh | bash -s -- zsh
+curl --proto '=https' --tlsv1.2 -fsSL \
+  https://raw.githubusercontent.com/ozzy-labs/bootstrap/main/install.sh | bash -s -- zsh
 
 # 2. ターミナルを再起動
 exit
 # 新しいターミナルを開く
 
 # 3. 開発ツールをセットアップ（mise, 言語環境, Docker, AI CLI, AI パワーツール等）
-curl -fsSL https://raw.githubusercontent.com/ozzy-labs/bootstrap/main/install.sh | bash -s -- local
+curl --proto '=https' --tlsv1.2 -fsSL \
+  https://raw.githubusercontent.com/ozzy-labs/bootstrap/main/install.sh | bash -s -- local
 
 # 4. インストール済みのものだけ認証を完了
 aws configure      # または aws configure sso
@@ -85,9 +99,49 @@ gemini              # 初回起動時に Google アカウントで認証
 
 # 5. 後日: mise / uv / npm 管理ツールをまとめて最新化
 ./install.sh update
+
+# 6. 環境の整合性を診断（任意のタイミング）
+./install.sh doctor
 ```
 
-事前に内容を確認したい場合は、従来どおり clone してから実行できます。
+### 4.1 内容を確認してから実行（本番ホスト推奨）
+
+実行前にスクリプトを読みたい場合は、ダウンロードして検査してから実行できます。
+
+```bash
+# 一時ファイルにダウンロード
+curl --proto '=https' --tlsv1.2 -fsSL \
+  https://raw.githubusercontent.com/ozzy-labs/bootstrap/main/install.sh \
+  -o /tmp/bootstrap-install.sh
+
+# 内容を確認
+less /tmp/bootstrap-install.sh
+
+# 実行
+bash /tmp/bootstrap-install.sh local
+```
+
+### 4.2 SHA256 でリリース版を検証する
+
+ピン留めした再現可能なインストールには、タグ付きリリースを使ってください。各 GitHub Release には `install.sh` と `install.sh.sha256` が同梱されています。
+
+```bash
+# 特定リリースに固定（v0.1.0 を最新タグに置き換える）
+TAG=v0.1.0
+BASE="https://github.com/ozzy-labs/bootstrap/releases/download/${TAG}"
+
+# スクリプトとチェックサムをダウンロード
+curl --proto '=https' --tlsv1.2 -fsSL "${BASE}/install.sh" -o install.sh
+curl --proto '=https' --tlsv1.2 -fsSL "${BASE}/install.sh.sha256" -o install.sh.sha256
+
+# 検証（"install.sh: OK" と出れば成功）
+sha256sum -c install.sh.sha256
+
+# 検証成功後にのみ実行
+bash install.sh local
+```
+
+### 4.3 clone して実行（コントリビュータ / fork 利用者向け）
 
 ```bash
 git clone https://github.com/ozzy-labs/bootstrap.git
@@ -547,6 +601,63 @@ SETUP_LOG=/tmp/update.log ./install.sh update
 - 耐障害性: 個別コマンドの失敗は警告表示のみで、全体処理は継続
 - ログ対応: `setup-local-linux.sh` と同じ `SETUP_LOG` 規約に従う
 - クロス OS: Linux（WSL2 / 非 WSL）と macOS で同等に動作
+
+---
+
+### 6.5 doctor.sh
+
+セットアップ済みの環境の整合性を診断するコマンド（変更は加えない）。OS アップデート後に動作が怪しい時や、新しいプロジェクトのセットアップでつまずいた際の状態確認に使えます。
+
+**6.5.1 診断項目**
+
+- **システム基本ツール** — `curl`, `git`, `unzip`, `xz`, `tar` の存在確認
+- **mise** — `~/.local/bin/mise` のバイナリ、`~/.local/bin` および mise shims の PATH 設定
+- **mise 管理ツール** — `node`, `pnpm`, `python`, `uv` が mise グローバル管理下か
+- **chezmoi drift** — リポジトリ内 `dotfiles/` との差分（`chezmoi diff`）を検出
+- **`~/.zshrc.d/`** — ディレクトリの存在と `~/.zshrc` からの読み込み設定
+
+**6.5.2 終了コード**
+
+| Code | 意味 |
+|---|---|
+| `0` | 健全（warning / error なし） |
+| `1` | 警告のみ（推奨ツール未インストール、drift 検出） |
+| `2` | エラーあり（必須システムツール欠落） |
+
+このため CI / ヘルスチェックパイプラインで `./install.sh doctor || echo "needs attention"` のように使えます（実問題がある時のみ非 0 で抜ける）。
+
+**6.5.3 使い方**
+
+```bash
+# install.sh dispatcher 経由
+./install.sh doctor
+
+# 直接実行
+./scripts/doctor.sh
+```
+
+`✅` 以外の各項目には対処コマンドがコピペ可能な形で併記されます。Doctor は **修復を実行しません** — コマンドを提示するだけで、実行判断はユーザーに委ねます。
+
+**6.5.4 出力例**
+
+```
+🩺 bootstrap doctor を実行中...
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+📊 診断結果
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+✅ [system-tools] curl: 利用可能
+✅ [system-tools] git: 利用可能
+✅ [mise] mise が利用可能 (2026.4.20 linux-x64)
+⚠️  [mise] PATH に mise shims が含まれていない（mise activate が必要）
+   ↳ 対処: eval "$(mise activate bash)"  # または zsh
+✅ [mise-tools] node は mise 管理下 (current: 24.15.0)
+⚠️  [chezmoi] ドットファイルに drift あり (12 行の差分)
+   ↳ 対処: chezmoi apply --source /path/to/bootstrap/dotfiles
+
+サマリー: ✅ 11  ⚠️  2  ❌ 0
+```
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,18 @@
 
 **One-shot host setup for AI-agent-driven development — WSL2 / Linux (Ubuntu/Debian-based) / macOS, Dev Container or direct host use**
 
+[![Lint](https://github.com/ozzy-labs/bootstrap/actions/workflows/lint.yaml/badge.svg)](https://github.com/ozzy-labs/bootstrap/actions/workflows/lint.yaml)
+[![Unit](https://github.com/ozzy-labs/bootstrap/actions/workflows/test-unit.yaml/badge.svg)](https://github.com/ozzy-labs/bootstrap/actions/workflows/test-unit.yaml)
+[![Smoke](https://github.com/ozzy-labs/bootstrap/actions/workflows/test-smoke.yaml/badge.svg)](https://github.com/ozzy-labs/bootstrap/actions/workflows/test-smoke.yaml)
+[![Integration](https://github.com/ozzy-labs/bootstrap/actions/workflows/test-integration.yaml/badge.svg)](https://github.com/ozzy-labs/bootstrap/actions/workflows/test-integration.yaml)
+[![License: MIT](https://img.shields.io/github/license/ozzy-labs/bootstrap)](LICENSE)
+[![Latest Release](https://img.shields.io/github/v/release/ozzy-labs/bootstrap?include_prereleases&label=release)](https://github.com/ozzy-labs/bootstrap/releases/latest)
+
 **English | [日本語](README.ja.md)**
 
 A comprehensive collection of shell scripts that bootstraps a development host (WSL2, Linux (Ubuntu/Debian-based), or macOS) with everything needed for modern, AI-agent-driven development. Works equally well whether you develop **inside Dev Containers** (recommended) or **directly on the host**. Ships AI agent CLIs (Claude Code / Codex / Copilot / Gemini) alongside a curated set of AI power tools (markitdown, ast-grep, yq, OCR/audio backends) so agents can read documents, search code, and operate on structured data out of the box.
+
+> **Why Bash + `curl | bash`?** This project consciously stays a single shell script with zero runtime dependencies — no Node.js, no npm, no compiled binary. Setup tools that *install* runtimes shouldn't *require* a runtime. The trade-off (no rich TUI) buys a strong asset: a one-line install that works on a fresh machine the day you provision it. See [ADR-0004](./docs/adr/ADR-0004-stay-bash-and-publish-readiness.md) for the full rationale.
 
 ## Table of Contents
 
@@ -18,6 +27,7 @@ A comprehensive collection of shell scripts that bootstraps a development host (
   - [6.2 setup-local-linux.sh](#62-setup-local-linuxsh)
   - [6.3 setup-local-macos.sh](#63-setup-local-macossh)
   - [6.4 update-tools.sh](#64-update-toolssh)
+  - [6.5 doctor.sh](#65-doctorsh)
 - [7. Troubleshooting](#7-troubleshooting)
 - [8. Contributing](#8-contributing)
 - [9. Changelog](#9-changelog)
@@ -64,16 +74,20 @@ bootstrap/
 
 ## 4. Quick Start
 
+> **Recommended invocation** uses explicit TLS pinning (`--proto '=https' --tlsv1.2`) so the install pipeline rejects any redirect to plain HTTP and any TLS version below 1.2. This is the same pattern used by `rustup` and `mise`.
+
 ```bash
 # 1. Set up zsh (recommended first)
-curl -fsSL https://raw.githubusercontent.com/ozzy-labs/bootstrap/main/install.sh | bash -s -- zsh
+curl --proto '=https' --tlsv1.2 -fsSL \
+  https://raw.githubusercontent.com/ozzy-labs/bootstrap/main/install.sh | bash -s -- zsh
 
 # 2. Restart your terminal
 exit
 # Open a new terminal
 
 # 3. Set up development tools (mise, languages, Docker, AI CLIs, AI power tools, ...)
-curl -fsSL https://raw.githubusercontent.com/ozzy-labs/bootstrap/main/install.sh | bash -s -- local
+curl --proto '=https' --tlsv1.2 -fsSL \
+  https://raw.githubusercontent.com/ozzy-labs/bootstrap/main/install.sh | bash -s -- local
 
 # 4. Complete required authentications (for what you installed)
 aws configure      # or: aws configure sso
@@ -85,9 +99,49 @@ gemini              # authenticate with Google account on first launch
 
 # 5. Later: upgrade every mise / uv / npm managed tool in one shot
 ./install.sh update
+
+# 6. Verify environment health any time
+./install.sh doctor
 ```
 
-If you prefer to inspect the repository first:
+### 4.1 Inspect-before-run (recommended for production hosts)
+
+If you prefer to read the script before running it, download first and review:
+
+```bash
+# Download to a temp file
+curl --proto '=https' --tlsv1.2 -fsSL \
+  https://raw.githubusercontent.com/ozzy-labs/bootstrap/main/install.sh \
+  -o /tmp/bootstrap-install.sh
+
+# Review the contents
+less /tmp/bootstrap-install.sh
+
+# Run it
+bash /tmp/bootstrap-install.sh local
+```
+
+### 4.2 Verify a release with SHA256
+
+For pinned, reproducible installs, use a tagged release. Each GitHub Release ships `install.sh` and `install.sh.sha256`:
+
+```bash
+# Pin to a specific release (replace v0.1.0 with the latest tag)
+TAG=v0.1.0
+BASE="https://github.com/ozzy-labs/bootstrap/releases/download/${TAG}"
+
+# Download both the script and its checksum
+curl --proto '=https' --tlsv1.2 -fsSL "${BASE}/install.sh" -o install.sh
+curl --proto '=https' --tlsv1.2 -fsSL "${BASE}/install.sh.sha256" -o install.sh.sha256
+
+# Verify (must print "install.sh: OK")
+sha256sum -c install.sh.sha256
+
+# Run only after verification succeeds
+bash install.sh local
+```
+
+### 4.3 Clone-and-run (for contributors / forkers)
 
 ```bash
 git clone https://github.com/ozzy-labs/bootstrap.git
@@ -547,6 +601,63 @@ SETUP_LOG=/tmp/update.log ./install.sh update
 - Resilient — a single command failure emits a warning but does not abort the run
 - Log-friendly — honors the same `SETUP_LOG` convention as `setup-local-linux.sh`
 - Cross-OS — works equally on Linux (WSL2 / non-WSL) and macOS
+
+---
+
+### 6.5 doctor.sh
+
+Diagnoses the integrity of an existing bootstrapped environment without making any changes. Useful when something feels off after a system update, or before debugging a new project setup.
+
+**6.5.1 What It Checks**
+
+- **System tools** — `curl`, `git`, `unzip`, `xz`, `tar` are present
+- **mise** — binary exists at `~/.local/bin/mise`, PATH wiring includes `~/.local/bin` and the mise shims directory
+- **mise-managed tools** — `node`, `pnpm`, `python`, `uv` are under mise's global config
+- **chezmoi drift** — runs `chezmoi diff` against the repository's `dotfiles/` to detect divergence
+- **`~/.zshrc.d/`** — directory exists and is sourced from `~/.zshrc`
+
+**6.5.2 Exit Codes**
+
+| Code | Meaning |
+|---|---|
+| `0` | Healthy (no warnings, no errors) |
+| `1` | Warnings only (recommended tools missing, drift detected) |
+| `2` | Errors (required system tools missing) |
+
+This makes it useful in CI / health-check pipelines — `./install.sh doctor || echo "needs attention"` exits non-zero only when there's a real problem.
+
+**6.5.3 Usage**
+
+```bash
+# Via install.sh dispatcher
+./install.sh doctor
+
+# Direct script execution
+./scripts/doctor.sh
+```
+
+Each non-`✅` finding is paired with a copy-paste-ready fix hint. The Doctor never executes fixes itself — it tells you what to run, and you decide.
+
+**6.5.4 Sample Output**
+
+```
+🩺 bootstrap doctor を実行中...
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+📊 診断結果
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+✅ [system-tools] curl: 利用可能
+✅ [system-tools] git: 利用可能
+✅ [mise] mise が利用可能 (2026.4.20 linux-x64)
+⚠️  [mise] PATH に mise shims が含まれていない（mise activate が必要）
+   ↳ 対処: eval "$(mise activate bash)"  # または zsh
+✅ [mise-tools] node は mise 管理下 (current: 24.15.0)
+⚠️  [chezmoi] ドットファイルに drift あり (12 行の差分)
+   ↳ 対処: chezmoi apply --source /path/to/bootstrap/dotfiles
+
+サマリー: ✅ 11  ⚠️  2  ❌ 0
+```
 
 ---
 


### PR DESCRIPTION
## Summary

公開直前の README を、ストレンジャーが GitHub で発見してから安心して install するまでの動線で再構成しました。

- ✅ CI / lint / release ステータスバッジを冒頭に配置
- ✅ 「なぜ Bash + curl\|bash か」哲学コール アウトを追加（ADR-0004 へのリンク）
- ✅ Quick Start を `curl --proto '=https' --tlsv1.2 -fsSL` の TLS 明示形に統一
- ✅ §4.1 内容を確認してから実行する手順を追加
- ✅ §4.2 SHA256 で pinned リリースを検証する手順を追加（#86 で添付した install.sh.sha256 を活用）
- ✅ §4.3 clone して実行する手順を整理
- ✅ §6.5 doctor.sh セクションを追加（#84 で追加した診断機能）
- ✅ README.md / README.ja.md を同期更新

Closes #89

## ストーリー

公開後にこの README に到達したユーザーが疑問に思う順番:

1. 「2026 年に shell script で配布？」 → **冒頭の哲学コール アウト**で先回り回答
2. 「これ走らせて大丈夫？」 → **§4.1 の inspect-before-run** と **§4.2 の SHA256 検証**
3. 「具体的に何が入る？」 → 既存の §3 / §6 に詳細
4. 「動かない時は？」 → §6.5 doctor で診断、§7 トラブルシューティング

## 対象外（明示）

- **asciinema デモ GIF/SVG**: 録画セッションが必要で別 issue で扱う
- **独自ドメイン** (bootstrap.ozzy-labs.dev 等): adoption signal が出てから検討

## Test plan

- [x] markdownlint — クリーン
- [x] gitleaks — クリーン
- [x] README.md / README.ja.md の構成同期確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)