### PR TITLE
chore(release): force initial release to v0.1.0

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,7 +7,8 @@
       "changelog-path": "CHANGELOG.md",
       "include-component-in-tag": false,
       "draft": false,
-      "prerelease": false
+      "prerelease": false,
+      "release-as": "0.1.0"
     }
   },
   "include-v-in-tag": true,


### PR DESCRIPTION
## Summary

`release-please-config.json` の package 設定に `\"release-as\": \"0.1.0\"` を追加し、初回リリースを **v0.1.0** に固定します。

## 背景

release-please は manifest が 0.0.0 から始まる場合、デフォルトで初回を **1.0.0** にバンプします（PR #94 が現在その提案中）。本プロジェクトは公開直後の状態であり、いきなり 1.0.0 を切ると SemVer 上の「stability commitment」を発信することになるため、まず 0.x 系で運用してから 1.0.0 へ昇格させる方針が安全です。

## 影響

- 本 PR がマージされると、release-please は既存の PR #94 を **更新（または再生成）して 0.1.0 を提案**します
- v0.1.0 リリース後、SemVer の通常運用に戻すため `release-as` フィールドは **手動で削除する必要があります**（次の Bug fix なら 0.1.1、feat なら 0.2.0）

## Follow-up

v0.1.0 リリース後、本フィールドの削除タスクを明記したコメントを Release PR に残すか、単独の chore PR を切ります。

## Test plan

- [x] yamllint / markdownlint / gitleaks — クリーン
- [ ] PR マージ後、release-please が PR #94 を 0.1.0 に更新することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)