### PR TITLE
fix(install): avoid set -e exit when no cloud / AI agent CLIs install

### DIFF
--- a/scripts/lib/install-ai-agents.sh
+++ b/scripts/lib/install-ai-agents.sh
@@ -88,5 +88,9 @@ install_ai_tools() {
     _mise_at_home reshim >/dev/null 2>&1 || true
   fi
 
-  [ "$any_installed" = "1" ] && echo "✅ AIツールインストール完了"
+  # 末尾は明示的に if/then を使う（`[ X ] && echo` は any_installed=0 のとき
+  # exit 1 を返し set -e でスクリプト全体を落とす）。
+  if [ "$any_installed" = "1" ]; then
+    echo "✅ AIツールインストール完了"
+  fi
 }

--- a/scripts/lib/install-cloud.sh
+++ b/scripts/lib/install-cloud.sh
@@ -82,5 +82,10 @@ install_cloud_tools() {
     fi
   fi
 
-  [ "$any_installed" = "1" ] && echo "✅ クラウドツールインストール完了"
+  # NOTE: 末尾を `[ X = "1" ] && echo` にすると any_installed=0 のとき
+  # 関数が exit 1 を返し、set -e でスクリプト全体が落ちる（canary や全クラウド
+  # CLI 無効化シナリオで再現）。明示的に if/then を使う。
+  if [ "$any_installed" = "1" ]; then
+    echo "✅ クラウドツールインストール完了"
+  fi
 }


### PR DESCRIPTION
## Summary

Resolves the root cause of #75 (Canary failure on Ubuntu Server, native install).

## 根本原因

\`install_cloud_tools\` と \`install_ai_tools\` の末尾の guard 行:

\`\`\`bash
[ "\$any_installed" = "1" ] && echo "✅ ...完了"
\`\`\`

ユーザーまたは CI マトリクス（canary の bare ubuntu-latest ジョブ）が **すべて無効化** （\`INSTALL_AWS_CLI=0\` / \`INSTALL_AZURE_CLI=0\` / \`INSTALL_GCLOUD_CLI=0\` と AI CLI 全 0）すると:

- \`[ "0" = "1" ]\` が **exit 1** を返す
- 関数も exit 1 を返す
- \`setup-local-linux.sh\` 冒頭の \`set -e\` がスクリプト全体を即時終了させる

canary の Ubuntu Server ジョブはまさにこの組み合わせで実行されるため、gitleaks インストール直後に何のエラー出力もなく \`exit 1\` で終了していました。

## 修正

末尾の guard を明示的な \`if [ ... ]; then ... fi\` に置換し、any_installed=0 の場合でも関数が exit 0 を返すように変更。

\`\`\`bash
if [ "\$any_installed" = "1" ]; then
  echo "✅ クラウドツールインストール完了"
fi
\`\`\`

\`install_cloud_tools\` / \`install_ai_tools\` の両方に同じ修正を適用。

## 既存性

このバグは #88 の lib 分割で導入したものではなく、**元の setup-local-linux.sh から存在していた既存バグ** です。canary の \"全 CLI 無効化\" マトリクスが定期的にトリガーしていたため、Issue #75 として可視化されていました。

## Test plan

- [x] shellcheck / shfmt / bats(35) クリーン
- [ ] 本 PR マージ後、canary を手動 trigger して 4/4 ジョブすべて緑になることを確認
- [ ] 確認できれば #75 を close

🤖 Generated with [Claude Code](https://claude.com/claude-code)