### PR TITLE
fix(copilot): restore @ozzylabs/skills markers in copilot-instructions.md

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -26,3 +26,7 @@ mise exec -- lefthook run pre-commit --all-files
 ```
 
 プロジェクト固有の検証は [AGENTS.md](../AGENTS.md) の「検証」セクションを参照。
+
+<!-- begin: @ozzylabs/skills -->
+<!-- このブロックは Sync skills ワークフローが自動同期する。手動編集禁止。 -->
+<!-- end: @ozzylabs/skills -->


### PR DESCRIPTION
## Summary

PR #74 (chore: sync commons defaults) で `.github/copilot-instructions.md` から `<!-- begin/end: @ozzylabs/skills -->` マーカーが削除されたため、`Sync skills` ワークフローが**毎回失敗**するようになっていました。マーカーを復活させて修正します。

## 失敗ログ

```
Error: .github/copilot-instructions.md is missing the
       '<!-- begin: @ozzylabs/skills -->' marker
##[error]Process completed with exit code 1.
```

PR #74 マージ直後の post-merge run ([25135860500](https://github.com/ozzy-labs/bootstrap/actions/runs/25135860500)) と、これ以降の毎週月曜スケジュール実行が連鎖的に失敗します。

## 根本原因

- **`.github/workflows/sync-skills.yaml`** は GitHub Copilot snippet を `replace_snippet` 関数で同期する設計（hardcoded、`skills_adapters` のリストとは独立）
- `replace_snippet` は target ファイルに begin マーカーが無いと early-error
- PR #74 の commons sync で marker ごとセクションが削除された → workflow が機能不能

## 修正

`.github/copilot-instructions.md` 末尾に空のマーカーブロックを復活:

\`\`\`markdown
<!-- begin: @ozzylabs/skills -->
<!-- このブロックは Sync skills ワークフローが自動同期する。手動編集禁止。 -->
<!-- end: @ozzylabs/skills -->
\`\`\`

awk 置換は **マーカーを含めて** 内容を upstream snippet で差し替えるため、間に何が入っているかは無関係。次回の Sync skills 実行で upstream の最新 snippet が自動的に反映される。

## Test plan

- [x] markdownlint クリーン
- [ ] マージ後、`gh workflow run sync-skills.yaml` を手動 trigger して緑になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)