### PR TITLE
chore(release): drop release-as override after v0.1.0 ships

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,8 +7,7 @@
       "changelog-path": "CHANGELOG.md",
       "include-component-in-tag": false,
       "draft": false,
-      "prerelease": false,
-      "release-as": "0.1.0"
+      "prerelease": false
     }
   },
   "include-v-in-tag": true,


### PR DESCRIPTION
v0.1.0 が公開されたため、初回リリースを 0.1.0 に固定するための one-shot 設定 `release-as: "0.1.0"` を削除します。残置すると次の feat: コミットで 0.2.0 に自動バンプしないため必須クリーンアップです。詳細はコミットメッセージ参照。