### PR TITLE
fix(lint): exclude CHANGELOG.md from markdownlint

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -16,3 +16,4 @@ ignores:
   - "**/node_modules"
   - "**/.claude/plans"
   - "**/*.bats"
+  - CHANGELOG.md


### PR DESCRIPTION
## Summary

- release-please が生成する `CHANGELOG.md` がセクション間に空行を 2 行挿入するため、`MD012/no-multiple-blanks` で main の lint が継続的に失敗していた
- `CHANGELOG.md` を `.markdownlint-cli2.yaml` の `ignores` に追加し、自動生成ファイルを lint 対象から外す
- release-please 側のテンプレートは変更不可、かつ手動編集は次回リリース時に上書きされるため lint 側で吸収するのが妥当

## Test plan

- [x] ローカルで `mise exec -- markdownlint-cli2 '**/*.md'` が pass すること（0 errors / CHANGELOG.md が finder から除外されること）
- [ ] CI の `lint` ジョブが pass すること