### PR TITLE
docs(rules): clarify fix vs ci commit type boundary

### DIFF
--- a/.agents/skills/commit-conventions/SKILL.md
+++ b/.agents/skills/commit-conventions/SKILL.md
@@ -22,6 +22,15 @@ Conventional Commits 1.0.0 に準拠する（commitlint で検証される）。
 | CI/CD 設定 | `ci` |
 | その他 | `chore` |
 
+### `fix` と `ci` の境界
+
+エンドユーザー（`install.sh` 利用者）の挙動が変わるかで判定する:
+
+- **`fix`:** `install.sh` / `scripts/` 配下のユーザーが実行するコードのバグ修正
+- **`ci`:** lint / formatter 設定（`.markdownlint-cli2.yaml`, `.yamllint.yaml` 等）、GitHub Actions、lefthook、その他開発者向けツール設定の修正
+
+例: `CHANGELOG.md` を markdownlint の対象から外す変更は `ci(lint):`（ユーザー挙動は不変）であって `fix:` ではない。
+
 ## Scope の判定
 
 変更が特定のディレクトリや機能に集中している場合、scope を付与する。ディレクトリ名や機能名から簡潔な scope を選ぶ:

--- a/.agents/skills/commit-conventions/SKILL.md
+++ b/.agents/skills/commit-conventions/SKILL.md
@@ -22,15 +22,6 @@ Conventional Commits 1.0.0 に準拠する（commitlint で検証される）。
 | CI/CD 設定 | `ci` |
 | その他 | `chore` |
 
-### `fix` と `ci` の境界
-
-エンドユーザー（`install.sh` 利用者）の挙動が変わるかで判定する:
-
-- **`fix`:** `install.sh` / `scripts/` 配下のユーザーが実行するコードのバグ修正
-- **`ci`:** lint / formatter 設定（`.markdownlint-cli2.yaml`, `.yamllint.yaml` 等）、GitHub Actions、lefthook、その他開発者向けツール設定の修正
-
-例: `CHANGELOG.md` を markdownlint の対象から外す変更は `ci(lint):`（ユーザー挙動は不変）であって `fix:` ではない。
-
 ## Scope の判定
 
 変更が特定のディレクトリや機能に集中している場合、scope を付与する。ディレクトリ名や機能名から簡潔な scope を選ぶ:

--- a/.claude/rules/git-workflow.md
+++ b/.claude/rules/git-workflow.md
@@ -18,6 +18,15 @@ Conventional Commits 形式を使用する:
 - description は英語で、簡潔に変更内容を記述
 - 破壊的変更: type 後に `!`（例: `feat!: redesign landing page`）
 
+### `fix` と `ci` の境界
+
+エンドユーザー（`install.sh` 利用者）の挙動が変わるかで判定する:
+
+- **`fix`:** `install.sh` / `scripts/` 配下のユーザーが実行するコードのバグ修正
+- **`ci`:** lint / formatter 設定（`.markdownlint-cli2.yaml`, `.yamllint.yaml` 等）、GitHub Actions、lefthook、その他開発者向けツール設定の修正
+
+例: `CHANGELOG.md` を markdownlint の対象から外す変更は `ci(lint):`（ユーザー挙動は不変）であって `fix:` ではない。
+
 ## PR
 
 - マージ方法: **squash merge のみ**


### PR DESCRIPTION
## Summary

- 直前の PR #104 (`fix(lint): exclude CHANGELOG.md from markdownlint`) は本来 `ci(lint):` であるべきだった（変更対象が CI/lint 設定ファイルで、`install.sh` 利用者の挙動は不変）
- `fix:` で commit したため release-please が patch リリース PR を起票してしまうノイズが発生
- 再発防止として、判定基準「エンドユーザー (`install.sh` 利用者) の挙動が変わるか」を明文化

### 配置先の選定

最初は `.agents/skills/commit-conventions/SKILL.md` に書いたが、self-review で以下が判明:

- `.agents/skills/` は `sync-skills.yaml` が `ozzy-labs/skills` から定期同期するため、上流に取り込まない限り次回 sync で **上書きされて消える**
- かつ「`install.sh` 利用者の挙動が境界」という判断は bootstrap 固有で、汎用 skill に含めるのは不適切

そのため、bootstrap 固有ルールが置かれている `.claude/rules/git-workflow.md` の `## コミット` 節下に補足を追記する形に切り替えた。

## Test plan

- [x] `markdownlint-cli2` が pass
- [x] commitlint が pass
- [ ] CI の lint ジョブが pass