### PR TITLE
fix(install): retry add-apt-repository on Launchpad failures

### DIFF
--- a/scripts/lib/apt.sh
+++ b/scripts/lib/apt.sh
@@ -23,6 +23,33 @@ apt_install_or_upgrade() {
   fi
 }
 
+# add-apt-repository を Launchpad への一時的な接続失敗に対してリトライする
+# api.launchpad.net への TCP 接続タイムアウトが間欠的に発生するため、
+# 指数バックオフで最大 3 回試行する。
+# $@: add-apt-repository に渡す引数（例: -y ppa:git-core/ppa）
+#
+# 戻り値: 0 = 成功、非 0 = 全試行失敗
+apt_add_repository_with_retry() {
+  local max_attempts=3
+  local delay=5
+  local attempt=1
+
+  while ((attempt <= max_attempts)); do
+    if sudo add-apt-repository "$@"; then
+      return 0
+    fi
+    if ((attempt < max_attempts)); then
+      echo "  ⚠️  add-apt-repository 失敗 (試行 ${attempt}/${max_attempts})、${delay}s 待機して再試行..."
+      sleep "$delay"
+      delay=$((delay * 3))
+    fi
+    attempt=$((attempt + 1))
+  done
+
+  echo "  ❌ add-apt-repository が ${max_attempts} 回試行しても失敗しました（Launchpad への接続不能の可能性）"
+  return 1
+}
+
 # dpkg のインストール状態をベースにした冪等インストール（コマンドではなくパッケージで判定）
 # build-essential のような複合パッケージ向け
 apt_install_pkg() {

--- a/scripts/lib/install-git.sh
+++ b/scripts/lib/install-git.sh
@@ -11,7 +11,7 @@ install_git_tools() {
 
   # Git公式PPAが既に追加されているかチェック
   if ! compgen -G "/etc/apt/sources.list.d/git-core-ubuntu-ppa-*.list" >/dev/null 2>&1; then
-    sudo add-apt-repository -y ppa:git-core/ppa >/dev/null
+    apt_add_repository_with_retry -y ppa:git-core/ppa >/dev/null
     sudo apt-get update >/dev/null
   fi
 

--- a/scripts/setup-local-linux.sh
+++ b/scripts/setup-local-linux.sh
@@ -424,7 +424,7 @@ if ! compgen -G "/etc/apt/sources.list.d/git-core-ubuntu-ppa-*.list" >/dev/null 
   if ! command -v add-apt-repository &>/dev/null; then
     sudo apt-get install -y software-properties-common >/dev/null
   fi
-  sudo add-apt-repository -y ppa:git-core/ppa >/dev/null
+  apt_add_repository_with_retry -y ppa:git-core/ppa >/dev/null
   sudo apt-get update >/dev/null
   echo "  ✅ Git公式PPAを追加しました"
 fi

--- a/tests/unit/apt.bats
+++ b/tests/unit/apt.bats
@@ -71,3 +71,69 @@ export -f apt-get
   [ "$status" -eq 0 ]
   [[ "$output" == *"bash"* ]]
 }
+
+# ------------------------------------------------------------------
+# apt_add_repository_with_retry: 1 回目で成功 → リトライしない
+# ------------------------------------------------------------------
+
+@test "apt_add_repository_with_retry: succeeds on first attempt" {
+  run apt_add_repository_with_retry -y ppa:test/ppa
+  [ "$status" -eq 0 ]
+  local count
+  count=$(grep -c "sudo add-apt-repository" "$MOCK_LOG")
+  [ "$count" -eq 1 ]
+}
+
+# ------------------------------------------------------------------
+# apt_add_repository_with_retry: 失敗 → リトライして成功
+# ------------------------------------------------------------------
+
+@test "apt_add_repository_with_retry: retries on failure and eventually succeeds" {
+  export MOCK_FAILS_LEFT=2
+  sudo() {
+    echo "sudo $*" >>"$MOCK_LOG"
+    if [ "$1" = "add-apt-repository" ] && [ "${MOCK_FAILS_LEFT:-0}" -gt 0 ]; then
+      MOCK_FAILS_LEFT=$((MOCK_FAILS_LEFT - 1))
+      export MOCK_FAILS_LEFT
+      return 1
+    fi
+    return 0
+  }
+  export -f sudo
+
+  # バックオフ待機をスキップしてテストを高速化
+  sleep() { :; }
+  export -f sleep
+
+  run apt_add_repository_with_retry -y ppa:test/ppa
+  [ "$status" -eq 0 ]
+  local count
+  count=$(grep -c "sudo add-apt-repository" "$MOCK_LOG")
+  [ "$count" -eq 3 ]
+  [[ "$output" == *"再試行"* ]]
+}
+
+# ------------------------------------------------------------------
+# apt_add_repository_with_retry: 最大試行回数まで失敗 → 非 0 を返す
+# ------------------------------------------------------------------
+
+@test "apt_add_repository_with_retry: fails after max attempts" {
+  sudo() {
+    echo "sudo $*" >>"$MOCK_LOG"
+    if [ "$1" = "add-apt-repository" ]; then
+      return 1
+    fi
+    return 0
+  }
+  export -f sudo
+
+  sleep() { :; }
+  export -f sleep
+
+  run apt_add_repository_with_retry -y ppa:test/ppa
+  [ "$status" -ne 0 ]
+  local count
+  count=$(grep -c "sudo add-apt-repository" "$MOCK_LOG")
+  [ "$count" -eq 3 ]
+  [[ "$output" == *"接続不能"* ]]
+}


### PR DESCRIPTION
## Summary

`add-apt-repository -y ppa:git-core/ppa` が `api.launchpad.net` への TCP 接続タイムアウトで失敗するケースを吸収する。

### 背景

2026-05-02 04:13 以降、`test-integration` ワークフローが連続して同じ箇所で失敗:

```text
File "/usr/lib/python3/dist-packages/httplib2/__init__.py", line 1153, in connect
    sock.connect((self.host, self.port))
TimeoutError: [Errno 110] Connection timed out
```

PR #104 / #106 / v0.1.1 release のすべての test-integration push 実行と再実行（22.04 / 24.04 両方）が同じ場所で失敗。コードは無関係（いずれも `install.sh` / `scripts/` を変更していない）で、外部依存 (Launchpad) への到達性が原因。

canary workflow の履歴でも 2026-04-29 16:22 / 2026-04-27 04:12 に同様の失敗があり、間欠的に再現する既知の問題と判断。

### 変更内容

- `scripts/lib/apt.sh`: `apt_add_repository_with_retry` ヘルパーを追加（最大 3 回、指数バックオフ 5s → 15s → 45s）
- `scripts/lib/install-git.sh` および `scripts/setup-local-linux.sh` の `sudo add-apt-repository` 呼び出しをヘルパーに置換
- `tests/unit/apt.bats` にユニットテスト 3 ケース追加（成功・リトライ後成功・最大試行失敗）

長時間障害には引き続き無力だが、短時間の Launchpad 接続不安定 (数秒〜数十秒) は吸収できるようになる。

## Test plan

- [x] `bats tests/unit/apt.bats` 全 6 ケース pass
- [x] `shfmt -d` / `shellcheck --severity=warning` pass
- [ ] CI の test-integration が pass（Launchpad の到達性が回復していれば本変更で確実に通過、もし依然タイムアウトでも 3 回試行のログが残る）