### PR TITLE
fix(install): replace add-apt-repository with direct PPA registration

### DIFF
--- a/scripts/lib/apt.sh
+++ b/scripts/lib/apt.sh
@@ -23,31 +23,52 @@ apt_install_or_upgrade() {
   fi
 }
 
-# add-apt-repository を Launchpad への一時的な接続失敗に対してリトライする
-# api.launchpad.net への TCP 接続タイムアウトが間欠的に発生するため、
-# 指数バックオフで最大 3 回試行する。
-# $@: add-apt-repository に渡す引数（例: -y ppa:git-core/ppa）
+# PPA を Launchpad の API を経由せず直接登録する。
+# add-apt-repository は api.launchpad.net に問い合わせて鍵 ID と URL を解決するが、
+# その API は間欠的に到達不能になるため、ここでは
+#   - GPG 鍵を keyserver.ubuntu.com から直接取得
+#   - APT source を /etc/apt/sources.list.d/ に直接書き込む
+# ことで api.launchpad.net への依存を排除する。
 #
-# 戻り値: 0 = 成功、非 0 = 全試行失敗
-apt_add_repository_with_retry() {
-  local max_attempts=3
-  local delay=5
-  local attempt=1
+# $1: PPA owner（例: git-core）
+# $2: PPA name（例: ppa）
+# $3: GPG key fingerprint（40 桁 16 進、例: E1DD270288B4E6030699E45FA1715D88E1DF1F24）
+# $4: keyring / list の basename（例: git-core）
+#
+# 戻り値: 0 = 成功、非 0 = 失敗
+apt_add_ppa() {
+  local owner="$1"
+  local name="$2"
+  local key_id="$3"
+  local basename="$4"
 
-  while ((attempt <= max_attempts)); do
-    if sudo add-apt-repository "$@"; then
-      return 0
-    fi
-    if ((attempt < max_attempts)); then
-      echo "  ⚠️  add-apt-repository 失敗 (試行 ${attempt}/${max_attempts})、${delay}s 待機して再試行..."
-      sleep "$delay"
-      delay=$((delay * 3))
-    fi
-    attempt=$((attempt + 1))
-  done
+  local keyring="/usr/share/keyrings/${basename}.gpg"
+  local list="/etc/apt/sources.list.d/${basename}.list"
+  local codename
+  codename=$(lsb_release -cs 2>/dev/null || echo "")
 
-  echo "  ❌ add-apt-repository が ${max_attempts} 回試行しても失敗しました（Launchpad への接続不能の可能性）"
-  return 1
+  if [ -z "$codename" ]; then
+    echo "  ❌ ディストリ codename を取得できません（lsb_release が必要）" >&2
+    return 1
+  fi
+
+  if [ -f "$list" ]; then
+    return 0
+  fi
+
+  local tmpkey
+  tmpkey=$(mktemp)
+  if ! curl -fsSL -o "$tmpkey" "https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x${key_id}"; then
+    rm -f "$tmpkey"
+    echo "  ❌ GPG 鍵 ${key_id} の取得に失敗しました（keyserver.ubuntu.com 到達不能の可能性）" >&2
+    return 1
+  fi
+  sudo gpg --dearmor -o "$keyring" <"$tmpkey"
+  rm -f "$tmpkey"
+  sudo chmod go+r "$keyring"
+
+  echo "deb [signed-by=${keyring}] https://ppa.launchpadcontent.net/${owner}/${name}/ubuntu ${codename} main" |
+    sudo tee "$list" >/dev/null
 }
 
 # dpkg のインストール状態をベースにした冪等インストール（コマンドではなくパッケージで判定）

--- a/scripts/lib/install-git.sh
+++ b/scripts/lib/install-git.sh
@@ -10,8 +10,9 @@ install_git_tools() {
   echo "🔧 バージョン管理ツールをインストール中..."
 
   # Git公式PPAが既に追加されているかチェック
-  if ! compgen -G "/etc/apt/sources.list.d/git-core-ubuntu-ppa-*.list" >/dev/null 2>&1; then
-    apt_add_repository_with_retry -y ppa:git-core/ppa >/dev/null
+  if [ ! -f /etc/apt/sources.list.d/git-core.list ] &&
+    ! compgen -G "/etc/apt/sources.list.d/git-core-ubuntu-ppa-*.list" >/dev/null 2>&1; then
+    apt_add_ppa "git-core" "ppa" "E1DD270288B4E6030699E45FA1715D88E1DF1F24" "git-core"
     sudo apt-get update >/dev/null
   fi
 

--- a/scripts/setup-local-linux.sh
+++ b/scripts/setup-local-linux.sh
@@ -415,16 +415,14 @@ else
 fi
 
 # git のインストール（最新安定版、後段でも install_git_tools が呼ばれるが
-# add-apt-repository を使うため最低限の git/PPA セットアップを先に行う）
+# 鍵 / source 設定を先に確立しておく）
 echo ""
 echo "🔧 Git（最新安定版）をインストール中..."
 
-if ! compgen -G "/etc/apt/sources.list.d/git-core-ubuntu-ppa-*.list" >/dev/null 2>&1; then
+if [ ! -f /etc/apt/sources.list.d/git-core.list ] &&
+  ! compgen -G "/etc/apt/sources.list.d/git-core-ubuntu-ppa-*.list" >/dev/null 2>&1; then
   echo "  ℹ️  Git公式PPAを追加しています..."
-  if ! command -v add-apt-repository &>/dev/null; then
-    sudo apt-get install -y software-properties-common >/dev/null
-  fi
-  apt_add_repository_with_retry -y ppa:git-core/ppa >/dev/null
+  apt_add_ppa "git-core" "ppa" "E1DD270288B4E6030699E45FA1715D88E1DF1F24" "git-core"
   sudo apt-get update >/dev/null
   echo "  ✅ Git公式PPAを追加しました"
 fi

--- a/tests/unit/apt.bats
+++ b/tests/unit/apt.bats
@@ -73,67 +73,55 @@ export -f apt-get
 }
 
 # ------------------------------------------------------------------
-# apt_add_repository_with_retry: 1 回目で成功 → リトライしない
+# apt_add_ppa: 正常系 — keyserver からの鍵取得 + sources.list.d への書き込みを行う
 # ------------------------------------------------------------------
 
-@test "apt_add_repository_with_retry: succeeds on first attempt" {
-  run apt_add_repository_with_retry -y ppa:test/ppa
+@test "apt_add_ppa: registers PPA via keyserver and launchpadcontent" {
+  lsb_release() { echo "jammy"; }
+  export -f lsb_release
+
+  curl() {
+    echo "curl $*" >>"$MOCK_LOG"
+    return 0
+  }
+  export -f curl
+
+  run apt_add_ppa "git-core" "ppa" "DEADBEEFCAFEBABE" "git-core"
   [ "$status" -eq 0 ]
-  local count
-  count=$(grep -c "sudo add-apt-repository" "$MOCK_LOG")
-  [ "$count" -eq 1 ]
+  grep -q "curl.*keyserver.ubuntu.com.*0xDEADBEEFCAFEBABE" "$MOCK_LOG"
+  grep -q "sudo gpg --dearmor -o /usr/share/keyrings/git-core.gpg" "$MOCK_LOG"
+  grep -q "sudo tee /etc/apt/sources.list.d/git-core.list" "$MOCK_LOG"
+  grep -q "sudo chmod go+r /usr/share/keyrings/git-core.gpg" "$MOCK_LOG"
 }
 
 # ------------------------------------------------------------------
-# apt_add_repository_with_retry: 失敗 → リトライして成功
+# apt_add_ppa: codename 取得失敗 → 非 0
 # ------------------------------------------------------------------
 
-@test "apt_add_repository_with_retry: retries on failure and eventually succeeds" {
-  export MOCK_FAILS_LEFT=2
-  sudo() {
-    echo "sudo $*" >>"$MOCK_LOG"
-    if [ "$1" = "add-apt-repository" ] && [ "${MOCK_FAILS_LEFT:-0}" -gt 0 ]; then
-      MOCK_FAILS_LEFT=$((MOCK_FAILS_LEFT - 1))
-      export MOCK_FAILS_LEFT
-      return 1
-    fi
-    return 0
-  }
-  export -f sudo
+@test "apt_add_ppa: fails when lsb_release returns empty codename" {
+  lsb_release() { echo ""; }
+  export -f lsb_release
 
-  # バックオフ待機をスキップしてテストを高速化
-  sleep() { :; }
-  export -f sleep
-
-  run apt_add_repository_with_retry -y ppa:test/ppa
-  [ "$status" -eq 0 ]
-  local count
-  count=$(grep -c "sudo add-apt-repository" "$MOCK_LOG")
-  [ "$count" -eq 3 ]
-  [[ "$output" == *"再試行"* ]]
-}
-
-# ------------------------------------------------------------------
-# apt_add_repository_with_retry: 最大試行回数まで失敗 → 非 0 を返す
-# ------------------------------------------------------------------
-
-@test "apt_add_repository_with_retry: fails after max attempts" {
-  sudo() {
-    echo "sudo $*" >>"$MOCK_LOG"
-    if [ "$1" = "add-apt-repository" ]; then
-      return 1
-    fi
-    return 0
-  }
-  export -f sudo
-
-  sleep() { :; }
-  export -f sleep
-
-  run apt_add_repository_with_retry -y ppa:test/ppa
+  run apt_add_ppa "git-core" "ppa" "DEADBEEF" "git-core"
   [ "$status" -ne 0 ]
-  local count
-  count=$(grep -c "sudo add-apt-repository" "$MOCK_LOG")
-  [ "$count" -eq 3 ]
-  [[ "$output" == *"接続不能"* ]]
+  [[ "$output" == *"codename を取得できません"* ]]
+}
+
+# ------------------------------------------------------------------
+# apt_add_ppa: 鍵取得失敗 → 非 0
+# ------------------------------------------------------------------
+
+@test "apt_add_ppa: fails when key fetch fails" {
+  lsb_release() { echo "jammy"; }
+  export -f lsb_release
+
+  curl() {
+    echo "curl $*" >>"$MOCK_LOG"
+    return 1
+  }
+  export -f curl
+
+  run apt_add_ppa "git-core" "ppa" "DEADBEEF" "git-core"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"取得に失敗"* ]]
 }


### PR DESCRIPTION
## Summary

`add-apt-repository ppa:git-core/ppa` の内部処理を手動で再現することで `api.launchpad.net` への依存を完全に排除する。

### 背景

`add-apt-repository` は内部で `api.launchpad.net` に問い合わせて GPG 鍵 ID と PPA URL を解決する。同 API は間欠的に到達不能になっており、PR #107 で導入したリトライ helper でも長時間障害（現在進行中）には無力だった。

### 採用アプローチ

PPA の中身（GPG 鍵 ID と APT URL）は公開情報で予測可能なため、`api.launchpad.net` を経由せず直接登録する:

- GPG 鍵: `keyserver.ubuntu.com` から `curl` で取得
- APT source: `/etc/apt/sources.list.d/git-core.list` に直接書き込み

bootstrap には既に同パターンの前例 (GitHub CLI / 他のサードパーティリポジトリ追加) があり、書き方の一貫性も取れる。

### 変更内容

- `scripts/lib/apt.sh`:
  - PR #107 で導入した `apt_add_repository_with_retry` を削除
  - 新ヘルパー `apt_add_ppa <owner> <name> <key_id> <basename>` を追加
- `scripts/lib/install-git.sh` / `scripts/setup-local-linux.sh`:
  - `apt_add_repository_with_retry -y ppa:git-core/ppa` の呼び出しを `apt_add_ppa "git-core" "ppa" "<key_id>" "git-core"` に置換
  - `software-properties-common` のインストール処理を削除（`add-apt-repository` を使わなくなったため）
  - 既存の `add-apt-repository` 形式の list ファイル（`git-core-ubuntu-ppa-*.list`）が残っていてもスキップする冪等性チェックを残す
- `tests/unit/apt.bats`:
  - リトライ helper のテストを `apt_add_ppa` のテストに差し替え（正常系・codename 取得失敗・鍵取得失敗の 3 ケース）

### GPG 鍵 ID

`E1DD270288B4E6030699E45FA1715D88E1DF1F24` — git-core/ppa で長年使われている公開値。万一誤りがあれば CI（test-integration）で検出可能。

## Test plan

- [x] `bats tests/unit/apt.bats` 全 6 ケース pass
- [x] `shfmt -d` / `shellcheck --severity=warning` pass
- [x] `software-properties-common` への参照が repo 全体から消えたことを確認
- [ ] CI の test-integration（22.04 / 24.04）が pass — `api.launchpad.net` 経由を通らず PPA が登録できることを実証