### PR TITLE
fix(install): bump git-core/ppa key fingerprint to 4096R rotation

### DIFF
--- a/scripts/lib/install-git.sh
+++ b/scripts/lib/install-git.sh
@@ -12,7 +12,7 @@ install_git_tools() {
   # Git公式PPAが既に追加されているかチェック
   if [ ! -f /etc/apt/sources.list.d/git-core.list ] &&
     ! compgen -G "/etc/apt/sources.list.d/git-core-ubuntu-ppa-*.list" >/dev/null 2>&1; then
-    apt_add_ppa "git-core" "ppa" "E1DD270288B4E6030699E45FA1715D88E1DF1F24" "git-core"
+    apt_add_ppa "git-core" "ppa" "F911AB184317630C59970973E363C90F8F1B6217" "git-core"
     sudo apt-get update >/dev/null
   fi
 


### PR DESCRIPTION
## Summary

- `scripts/lib/install-git.sh` の git-core/ppa GPG fingerprint を **F911AB184317630C59970973E363C90F8F1B6217** (4096R, [Launchpad signing key](https://launchpad.net/~git-core/+archive/ubuntu/ppa)) に差し替え。
- 旧 fingerprint `E1DD270288B4E6030699E45FA1715D88E1DF1F24` は RSA 1024 で、Ubuntu 24.04+ の apt-secure に `untrusted public key algorithm: rsa1024` として拒否される ([Ubuntu Discourse: New requirements for APT repository signing in 24.04](https://discourse.ubuntu.com/t/new-requirements-for-apt-repository-signing-in-24-04/42854))。Ubuntu 25.10 (questing) canary では `NO_PUBKEY E363C90F8F1B6217` warning も同時発生し、**warning ではなく error として扱われる**ため `apt-get update` が失敗していた。
- Launchpad は影響を受ける PPA を 4096R 鍵に順次 migrate 中で、git-core/ppa は既にローテート済み (短鍵 ID `E363C90F8F1B6217` はこの新鍵の末尾 16 桁)。本 PR で fingerprint を新鍵に揃えるだけで根本解決する。

## Test plan

- [ ] `gh workflow run canary.yaml` で ubuntu:rolling / ubuntu:devel 両 matrix が緑
- [ ] LTS (ubuntu:latest = 24.04) も従前通り通る
- [ ] ローカル: `./tests/integration/run.sh devel`

Closes #110
Closes #111