### PR TITLE
docs(apt): update apt_add_ppa fingerprint example to 4096R rotation key

### DIFF
--- a/scripts/lib/apt.sh
+++ b/scripts/lib/apt.sh
@@ -32,7 +32,7 @@ apt_install_or_upgrade() {
 #
 # $1: PPA owner（例: git-core）
 # $2: PPA name（例: ppa）
-# $3: GPG key fingerprint（40 桁 16 進、例: E1DD270288B4E6030699E45FA1715D88E1DF1F24）
+# $3: GPG key fingerprint（40 桁 16 進、例: F911AB184317630C59970973E363C90F8F1B6217）
 # $4: keyring / list の basename（例: git-core）
 #
 # 戻り値: 0 = 成功、非 0 = 失敗


### PR DESCRIPTION
## Summary

- `scripts/lib/apt.sh` の `apt_add_ppa` docstring (`$3` 引数説明) に残っていた旧 RSA1024 鍵 `E1DD270288B4E6030699E45FA1715D88E1DF1F24` を、現在実装で参照している 4096R 鍵 `F911AB184317630C59970973E363C90F8F1B6217` (git-core/ppa) に差し替え。
- #112 のセルフレビューで Info として残した実装と doc の不整合を解消する純粋なドキュメント修正。挙動変更なし。

## Test plan

- [x] `shellcheck --severity=warning scripts/lib/apt.sh` 通過
- [x] gitleaks / trivy (lefthook pre-commit) 通過
- [x] commitlint 通過