### PR TITLE
fix(install): apply git-core/ppa 4096R fingerprint in setup-local-linux too

### DIFF
--- a/scripts/setup-local-linux.sh
+++ b/scripts/setup-local-linux.sh
@@ -422,7 +422,7 @@ echo "🔧 Git（最新安定版）をインストール中..."
 if [ ! -f /etc/apt/sources.list.d/git-core.list ] &&
   ! compgen -G "/etc/apt/sources.list.d/git-core-ubuntu-ppa-*.list" >/dev/null 2>&1; then
   echo "  ℹ️  Git公式PPAを追加しています..."
-  apt_add_ppa "git-core" "ppa" "E1DD270288B4E6030699E45FA1715D88E1DF1F24" "git-core"
+  apt_add_ppa "git-core" "ppa" "F911AB184317630C59970973E363C90F8F1B6217" "git-core"
   sudo apt-get update >/dev/null
   echo "  ✅ Git公式PPAを追加しました"
 fi


### PR DESCRIPTION
## Summary

PR #112 で `scripts/lib/install-git.sh` の git-core/ppa fingerprint を 4096R 鍵に更新したが、**同じ PPA 登録ロジックが `scripts/setup-local-linux.sh:425` にも重複して存在し、そこには旧 RSA1024 fingerprint `E1DD2702...` が残ったままだった**。

`setup-local-linux.sh` は `install_git_tools` の前段で動き、ここで `/etc/apt/sources.list.d/git-core.list` が既に作成されてしまうため、後段の `install_git_tools`（PR #112 で更新済み）はスキップされ、PR #112 の fix が canary には到達していなかった。

ログでも `setup-local-linux.sh:424` 由来のメッセージ「ℹ️ Git公式PPAを追加しています...」直後に署名検証が失敗していることを確認した。

```text
🔧 Git（最新安定版）をインストール中...
  ℹ️  Git公式PPAを追加しています...     ← setup-local-linux.sh:424
W: OpenPGP signature verification failed: ...
   invalid: E1DD2702...8E1DF1F24 (untrusted public key algorithm: rsa1024)
   NO_PUBKEY E363C90F8F1B6217
```

## Root cause

`setup-local-linux.sh:425` と `lib/install-git.sh:15` で同じ fingerprint が重複定義されており、PR #112 では片方しか更新していなかった (DRY 違反)。

## Test plan

- [x] `shellcheck --severity=warning scripts/setup-local-linux.sh` 通過
- [x] gitleaks / trivy / commitlint (lefthook pre-commit + commit-msg) 通過
- [x] `grep -rn 'E1DD2702' scripts/` で旧 fingerprint 参照が全域から消えたことを確認
- [ ] **マージ後に `gh workflow run canary.yaml` で ubuntu:rolling / ubuntu:devel 両 matrix が緑になることを実機検証** (今回はマージ後即実行する)

## Follow-up (別 PR で検討)

- PPA fingerprint の重複定義を constants 化して 1 箇所集約
- \`apt_add_ppa\` に取得鍵の fingerprint 検証 step を追加し、不一致時に fail させる

Re-fixes #110 #111 (#115 #116 are duplicates and will close upon canary green)