### PR TITLE
chore: sync commons defaults

### DIFF
--- a/.claude/rules/git-workflow.md
+++ b/.claude/rules/git-workflow.md
@@ -18,15 +18,6 @@ Conventional Commits 形式を使用する:
 - description は英語で、簡潔に変更内容を記述
 - 破壊的変更: type 後に `!`（例: `feat!: redesign landing page`）
 
-### `fix` と `ci` の境界
-
-エンドユーザー（`install.sh` 利用者）の挙動が変わるかで判定する:
-
-- **`fix`:** `install.sh` / `scripts/` 配下のユーザーが実行するコードのバグ修正
-- **`ci`:** lint / formatter 設定（`.markdownlint-cli2.yaml`, `.yamllint.yaml` 等）、GitHub Actions、lefthook、その他開発者向けツール設定の修正
-
-例: `CHANGELOG.md` を markdownlint の対象から外す変更は `ci(lint):`（ユーザー挙動は不変）であって `fix:` ではない。
-
 ## PR
 
 - マージ方法: **squash merge のみ**

--- a/.commons/sync.yaml
+++ b/.commons/sync.yaml
@@ -1,7 +1,7 @@
 # Auto-updated by commons sync.sh
 # 'pinned' is user-editable — add or remove paths freely
-commit: 346a41e4fa30713a49c7f6e3c6cadf212db06949
-synced_at: 2026-04-27T00:42:47Z
+commit: 7c831aa4e3c35428d6e4bcc31a216aa682c0fb25
+synced_at: 2026-05-05T10:20:08Z
 skills_commit: 4d35fa3683789c8b4a8633bf6aa5bf8e5e7bc230
 skills_adapters:
   - claude-code

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -26,20 +26,3 @@ mise exec -- lefthook run pre-commit --all-files
 ```
 
 プロジェクト固有の検証は [AGENTS.md](../AGENTS.md) の「検証」セクションを参照。
-
-<!-- begin: @ozzylabs/skills -->
-
-## Available Skills
-
-- `commit` — 変更をステージし、Conventional Commits でコミットする。プッシュや PR 作成は行わない。
-- `commit-conventions` — Conventional Commits のメッセージ生成ルール（Type/Scope 判定表、フォーマット）。他スキルから参照される。
-- `drive` — Issue から実装・PR 作成・セルフレビュー・修正を自動で回し、merge-ready な PR を出す。Issue 番号またはテキスト指示を受け取る。オプションでマージまで実行可能。
-- `implement` — Issue または指示をもとに、ブランチ作成・実装計画・コード変更を行う。Issue 番号またはテキスト指示を受け取る。
-- `lint` — 全リンターを自動修正付きで実行し、結果を報告する。コード品質チェック、フォーマット、型チェック、セキュリティスキャンを含む。
-- `lint-rules` — 拡張子別リンター・フォーマッターのコマンド対応表と型チェックルール。他スキルから参照される。
-- `pr` — コミット済みの変更をリモートにプッシュし、PR を作成・更新する。
-- `review` — コード変更や PR をレビューし、問題点・改善案を報告する。PR 番号または空（ワーキングツリー）を受け取る。
-- `ship` — lint・コミット・PR 作成を一括実行する。変更に対して lint → コミット → PR 作成を順に実行する統合パイプライン。
-- `test` — ビルド・テスト・型チェックを実行し、結果を報告する。
-
-<!-- end: @ozzylabs/skills -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,4 @@
+<!-- begin: ozzy-labs/commons -->
 # Contributing
 
 This is a personal project maintained by [ozzy-labs](https://github.com/ozzy-labs). External contributions are not currently accepted.
@@ -9,3 +10,4 @@ If you find a bug or have an idea for improvement, please open an issue.
 ## License
 
 By interacting with this project, you agree that any contributions you make will be licensed under the [MIT License](LICENSE).
+<!-- end: ozzy-labs/commons -->


### PR DESCRIPTION
Manual sync from ozzy-labs/commons. Picks up uv 0.11.8 pin (ozzy-labs/commons#98), npm:pnpm backend (ozzy-labs/commons#100), and pr-check dependabot/release-please skip (ozzy-labs/commons#97). Part of the 10-consumer rollout after starlight-theme pilot.