### PR TITLE
fix(install): pin pnpm to 10.33.2 to avoid aqua-registry mismatch

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,7 +1,9 @@
 [tools]
 # Runtime & package managers (commitlint に必要)
 node = "24"
-pnpm = "10"
+# pnpm は 10.33.2 に pin（aqua-registry 段階制約の影響回避）。
+# 詳細: scripts/lib/install-languages.sh
+pnpm = "10.33.2"
 
 # Linters & formatters
 biome = "latest"

--- a/dotfiles/dot_config/mise/config.toml
+++ b/dotfiles/dot_config/mise/config.toml
@@ -12,9 +12,9 @@ always_keep_install = false
 # 上書きするため、グローバルに残すツールはここで明示的に列挙する必要がある。
 # このファイルに無いツールは chezmoi apply 後に config から消える。
 node = "lts"
-# pnpm は 10 系に pin。pnpm 11 はリリースアセットの命名規則が変更され、
-# mise の aqua レジストリが追従していないため @latest が解決失敗する。
-pnpm = "10"
+# pnpm は 10.33.2 に pin。aqua-registry の段階制約で 10.33.3 が誤って
+# tar.gz (v11+) 枝に落ちるため。詳細は scripts/lib/install-languages.sh 参照。
+pnpm = "10.33.2"
 python = "latest"
 uv = "latest"
 gitleaks = "latest"

--- a/scripts/lib/install-languages.sh
+++ b/scripts/lib/install-languages.sh
@@ -18,11 +18,13 @@ install_mise_and_languages() {
     echo ""
     echo "📦 Node.js と pnpm を mise でインストール中..."
     mise_use_global "node@lts" "Node.js LTS"
-    # NOTE: pnpm は 10 系に pin。pnpm 11 でリリースアセットの命名規則が
-    # `pnpm-linux-x64` から `pnpm-linux-x64.tar.gz` に変更されたが、mise の
-    # aqua レジストリが追従しておらず @latest が解決失敗する。aqua-registry
-    # 側の修正が入り次第、@latest に戻す。
-    mise_use_global "pnpm@10" "pnpm"
+    # NOTE: pnpm は 10.33.2 に pin。aqua-registry の pnpm/pnpm registry.yaml は
+    # `<= 10.33.2` を raw asset、`<= 11.0.4` を tar.gz として扱う段階制約で、
+    # 10.33.3 は `<= 10.33.2` を外れて tar.gz 枝に落ちるが pnpm v10 は raw 配布の
+    # ままなので no asset エラーになる。aqua-registry が 10.33.3 を raw 制約に
+    # 含めるよう修正されたら `@10` に戻す。
+    # https://github.com/aquaproj/aqua-registry/blob/main/pkgs/pnpm/pnpm/registry.yaml
+    mise_use_global "pnpm@10.33.2" "pnpm"
   fi
 
   # Python + uv を mise で導入

--- a/scripts/setup-local-macos.sh
+++ b/scripts/setup-local-macos.sh
@@ -158,11 +158,13 @@ install_mise_and_languages() {
   echo ""
   echo "📦 Node.js / pnpm / Python / uv を mise でインストール中..."
   mise_use_global "node@lts" "Node.js LTS"
-  # NOTE: pnpm は 10 系に pin。pnpm 11 でリリースアセットの命名規則が
-  # `pnpm-linux-x64` から `pnpm-linux-x64.tar.gz` に変更されたが、mise の
-  # aqua レジストリが追従しておらず @latest が解決失敗する。aqua-registry
-  # 側の修正が入り次第、@latest に戻す。
-  mise_use_global "pnpm@10" "pnpm"
+  # NOTE: pnpm は 10.33.2 に pin。aqua-registry の pnpm/pnpm registry.yaml は
+  # `<= 10.33.2` を raw asset、`<= 11.0.4` を tar.gz として扱う段階制約で、
+  # 10.33.3 は `<= 10.33.2` を外れて tar.gz 枝に落ちるが pnpm v10 は raw 配布の
+  # ままなので no asset エラーになる。aqua-registry が 10.33.3 を raw 制約に
+  # 含めるよう修正されたら `@10` に戻す。
+  # https://github.com/aquaproj/aqua-registry/blob/main/pkgs/pnpm/pnpm/registry.yaml
+  mise_use_global "pnpm@10.33.2" "pnpm"
   mise_use_global "python@latest" "Python"
   mise_use_global "uv@latest" "uv"
   echo "✅ mise + 言語環境インストール完了"


### PR DESCRIPTION
## Summary

- aqua-registry の pnpm 制約は `<= 10.33.2` を raw、`<= 11.0.4` を tar.gz として扱う段階制約のため、新リリース **10.33.3** が tar.gz 枝に落ちる
- pnpm v10 は依然として raw バイナリ配布のため `pnpm-linux-x64.tar.gz` の取得に失敗し、`test-integration` (ubuntu:22.04 / 24.04) のコンテナ内 `setup-local-linux.sh` で pnpm インストールがこける
- aqua-registry が 10.33.3 を raw 制約に組み込むまで暫定的に **10.33.2** へ明示ピン

## Failure (main / run 25373588838)

```
mise pnpm@10.33.3    [1/3] install
mise ERROR Failed to install aqua:pnpm/pnpm@10: no asset found: pnpm-linux-x64.tar.gz
Available assets:
pnpm-linux-x64
...
```

## Changes

- `scripts/lib/install-languages.sh`: `pnpm@10` → `pnpm@10.33.2`（コメント更新）
- `scripts/setup-local-macos.sh`: 同上
- `dotfiles/dot_config/mise/config.toml`: `pnpm = "10"` → `"10.33.2"`
- `.mise.toml`: 同上

aqua-registry: https://github.com/aquaproj/aqua-registry/blob/main/pkgs/pnpm/pnpm/registry.yaml

## Test plan

- [x] `mise install pnpm@10.33.2` がローカルで成功
- [ ] CI の test-integration（ubuntu:22.04 / 24.04）が緑に戻る