### PR TITLE
fix(lefthook): unpin base; override via skip+replacement in lefthook.yaml

### DIFF
--- a/.commons/sync.yaml
+++ b/.commons/sync.yaml
@@ -1,7 +1,7 @@
 # Auto-updated by commons sync.sh
 # 'pinned' is user-editable — add or remove paths freely
-commit: fe046f2142c1f79fa0966f015163c883b56da03f
-synced_at: 2026-05-06T07:51:14Z
+commit: ac77e891c557659e0e9d1c3f76ad58178691553b
+synced_at: 2026-05-06T08:54:46Z
 skills_commit: 4d35fa3683789c8b4a8633bf6aa5bf8e5e7bc230
 skills_adapters:
   - claude-code
@@ -21,6 +21,6 @@ pinned:
   - .vscode/extensions.json
   - .vscode/settings.json
   - biome.json
-  - lefthook-base.yaml
+  - lefthook.yaml
   - renovate.json
   - trivy.yaml

--- a/lefthook-base.yaml
+++ b/lefthook-base.yaml
@@ -4,31 +4,44 @@
 #   extends:
 #     - lefthook-base.yaml
 #
-# Then add repo-specific commands (biome, taplo, ruff, etc.)
+# Then add repo-specific commands (biome, ruff, etc.)
+#
+# All commands run via `mise exec --` so hooks succeed even when the calling
+# shell hasn't run `mise activate` (e.g. `bash -c 'git commit ...'`, IDE
+# integrations). See ozzy-labs/commons#117.
 
 glob_matcher: doublestar
 
 commit-msg:
   commands:
     commitlint:
-      run: commitlint --edit {1}
+      # NODE_PATH lets commitlint resolve @commitlint/config-conventional when
+      # both packages are installed via mise's npm: backend, which places each
+      # package in its own isolated install dir.
+      run: |
+        NODE_PATH="$(mise where npm:@commitlint/config-conventional 2>/dev/null)/lib/node_modules" \
+          mise exec -- commitlint --edit {1}
 
 pre-commit:
   parallel: true
   commands:
     shell:
       glob: "**/*.sh"
-      run: shfmt -w {staged_files} && shellcheck --severity=warning {staged_files}
+      run: mise exec -- shfmt -w {staged_files} && mise exec -- shellcheck {staged_files}
       stage_fixed: true
     markdownlint:
       glob: "**/*.md"
-      run: markdownlint-cli2 --fix {staged_files}
+      run: mise exec -- markdownlint-cli2 --fix {staged_files}
       stage_fixed: true
     yaml:
       glob: "**/*.{yaml,yml}"
-      run: yamlfmt {staged_files} && yamllint -c .yamllint.yaml {staged_files}
+      run: mise exec -- yamlfmt {staged_files} && mise exec -- yamllint -c .yamllint.yaml {staged_files}
+      stage_fixed: true
+    taplo:
+      glob: "**/*.toml"
+      run: mise exec -- taplo format {staged_files}
       stage_fixed: true
     gitleaks:
-      run: gitleaks protect --staged --no-banner
+      run: mise exec -- gitleaks protect --staged --no-banner
     trivy:
-      run: trivy fs --scanners vuln --exit-code 1 --no-progress .
+      run: mise exec -- trivy fs --scanners vuln,secret --exit-code 1 --no-progress .

--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -1,2 +1,37 @@
 extends:
   - lefthook-base.yaml
+
+# Bootstrap-specific overrides on top of the shared base from commons.
+#
+# lefthook's extends merge has base-wins semantics: when a command key exists
+# in both base and local, the base entry wins (verified with lefthook 2.1.6
+# `lefthook dump`). To substitute a base command we mark it `skip: true`
+# locally and add a replacement under a different key.
+#
+# Unpinning lefthook-base.yaml in .commons/sync.yaml lets future commons
+# improvements (e.g. ozzy-labs/commons#117 mise-exec wrapping) flow in
+# automatically; bootstrap-specific behavior stays here.
+pre-commit:
+  commands:
+    # Substitute base `shell` with severity=warning. Bootstrap shell scripts
+    # intentionally produce SC2088 (tilde-in-log) and other info-level
+    # findings. See ozzy-labs/bootstrap#6.
+    #
+    # `run:` here is a stub; lefthook validate requires it to be a string,
+    # but at execution time base's `run:` wins via extends merge — and `skip`
+    # short-circuits both before either runs.
+    shell:
+      run: "true"
+      skip: true
+    bootstrap-shell:
+      glob: "**/*.sh"
+      run: mise exec -- shfmt -w {staged_files} && mise exec -- shellcheck --severity=warning {staged_files}
+      stage_fixed: true
+    # Substitute base `trivy` with --scanners vuln only. Bootstrap has no
+    # package manifest, so trivy's secret scanner is redundant with gitleaks.
+    # See ozzy-labs/bootstrap#63.
+    trivy:
+      run: "true"
+      skip: true
+    bootstrap-trivy:
+      run: mise exec -- trivy fs --scanners vuln --exit-code 1 --no-progress .


### PR DESCRIPTION
## Summary

- `.commons/sync.yaml`: `lefthook-base.yaml` を pin リストから削除、`lefthook.yaml` を pin に追加
- `lefthook-base.yaml`: 現行 commons/dist と完全一致（#117/#118 の mise-exec ラップ・taplo・NODE_PATH を取り込み）
- `lefthook.yaml`: bootstrap 固有のオーバーライド（`shellcheck --severity=warning` / `trivy --scanners vuln`）を **skip+replacement パターン**で表現

## Why

これまで `lefthook-base.yaml` を pin して bootstrap 固有の 2 行（severity / scanners）を保持していたが、副作用として **commons の改善（#117 mise-exec ラップ, #118 taplo, #119 sync.sh フル-copy 化）が bootstrap に流れない** drift が発生していた。

lefthook の extends merge は **base が勝つ** 仕様（lefthook 2.1.6 で `lefthook dump` 検証済）。つまりローカル側で同名コマンドを書いても base の `run:` が優先されるので、上書きには **`skip: true` + 別名で再定義** する必要がある。

ベース側 commands に `skip: true` だけ追加すると `lefthook validate` が `Value is null but should be string` で落ちるので、ダミーの `run: "true"` を併記している（base の run が merge で上書きするので実行はされない）。

## Test plan

- [x] `mise exec -- lefthook validate` All good
- [x] `mise exec -- lefthook dump` で `shell` / `trivy` が `skip: true`、`bootstrap-shell` / `bootstrap-trivy` が想定どおり実行されることを確認
- [x] `env -i HOME=$HOME PATH=/usr/bin:/bin:~/.local/bin bash -c 'mise exec -- lefthook run commit-msg <msg>'` で commitlint PASS（mise activate 不要 ＝ #117 fix が効いている）
- [x] `lefthook run pre-commit --command shell --command bootstrap-shell --command trivy --command bootstrap-trivy --all-files --force` で `bootstrap-shell` / `bootstrap-trivy` のみ実行・base はスキップ