### PR TITLE
chore: rename repo references from bootstrap to agentic-bootstrap

### DIFF
--- a/.github/workflows/canary.yaml
+++ b/.github/workflows/canary.yaml
@@ -36,7 +36,7 @@ jobs:
           file: tests/integration/Dockerfile
           build-args: |
             UBUNTU_VERSION=${{ matrix.ubuntu-tag }}
-          tags: bootstrap-canary:${{ matrix.ubuntu-tag }}
+          tags: agentic-bootstrap-canary:${{ matrix.ubuntu-tag }}
           load: true
           cache-from: type=gha,scope=canary-${{ matrix.ubuntu-tag }}
           cache-to: type=gha,scope=canary-${{ matrix.ubuntu-tag }},mode=max
@@ -46,7 +46,7 @@ jobs:
           GITHUB_TOKEN_FOR_MISE: ${{ secrets.GITHUB_TOKEN }}
         run: |
           docker run --rm -e "GITHUB_TOKEN=$GITHUB_TOKEN_FOR_MISE" \
-            bootstrap-canary:${{ matrix.ubuntu-tag }}
+            agentic-bootstrap-canary:${{ matrix.ubuntu-tag }}
 
       - name: Open issue on failure
         if: failure()

--- a/.github/workflows/test-integration.yaml
+++ b/.github/workflows/test-integration.yaml
@@ -51,7 +51,7 @@ jobs:
           file: tests/integration/Dockerfile
           build-args: |
             UBUNTU_VERSION=${{ matrix.ubuntu }}
-          tags: bootstrap-test:${{ matrix.ubuntu }}
+          tags: agentic-bootstrap-test:${{ matrix.ubuntu }}
           load: true
           cache-from: type=gha,scope=ubuntu-${{ matrix.ubuntu }}
           cache-to: type=gha,scope=ubuntu-${{ matrix.ubuntu }},mode=max
@@ -61,4 +61,4 @@ jobs:
           # mise の GitHub API 叩きを認証して rate limit を 5000/hr に上げる
           GITHUB_TOKEN_FOR_MISE: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          docker run --rm -e "GITHUB_TOKEN=$GITHUB_TOKEN_FOR_MISE" bootstrap-test:${{ matrix.ubuntu }}
+          docker run --rm -e "GITHUB_TOKEN=$GITHUB_TOKEN_FOR_MISE" agentic-bootstrap-test:${{ matrix.ubuntu }}

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,13 +1,13 @@
-# bootstrap
+# agentic-bootstrap
 
 **開発ホストを AI エージェント駆動開発向けにワンコマンド構築 — WSL2 / Linux (Ubuntu/Debian-based) / macOS、Dev Container / 直接開発の両対応**
 
-[![Lint](https://github.com/ozzy-labs/bootstrap/actions/workflows/lint.yaml/badge.svg)](https://github.com/ozzy-labs/bootstrap/actions/workflows/lint.yaml)
-[![Unit](https://github.com/ozzy-labs/bootstrap/actions/workflows/test-unit.yaml/badge.svg)](https://github.com/ozzy-labs/bootstrap/actions/workflows/test-unit.yaml)
-[![Smoke](https://github.com/ozzy-labs/bootstrap/actions/workflows/test-smoke.yaml/badge.svg)](https://github.com/ozzy-labs/bootstrap/actions/workflows/test-smoke.yaml)
-[![Integration](https://github.com/ozzy-labs/bootstrap/actions/workflows/test-integration.yaml/badge.svg)](https://github.com/ozzy-labs/bootstrap/actions/workflows/test-integration.yaml)
-[![License: MIT](https://img.shields.io/github/license/ozzy-labs/bootstrap)](LICENSE)
-[![Latest Release](https://img.shields.io/github/v/release/ozzy-labs/bootstrap?include_prereleases&label=release)](https://github.com/ozzy-labs/bootstrap/releases/latest)
+[![Lint](https://github.com/ozzy-labs/agentic-bootstrap/actions/workflows/lint.yaml/badge.svg)](https://github.com/ozzy-labs/agentic-bootstrap/actions/workflows/lint.yaml)
+[![Unit](https://github.com/ozzy-labs/agentic-bootstrap/actions/workflows/test-unit.yaml/badge.svg)](https://github.com/ozzy-labs/agentic-bootstrap/actions/workflows/test-unit.yaml)
+[![Smoke](https://github.com/ozzy-labs/agentic-bootstrap/actions/workflows/test-smoke.yaml/badge.svg)](https://github.com/ozzy-labs/agentic-bootstrap/actions/workflows/test-smoke.yaml)
+[![Integration](https://github.com/ozzy-labs/agentic-bootstrap/actions/workflows/test-integration.yaml/badge.svg)](https://github.com/ozzy-labs/agentic-bootstrap/actions/workflows/test-integration.yaml)
+[![License: MIT](https://img.shields.io/github/license/ozzy-labs/agentic-bootstrap)](LICENSE)
+[![Latest Release](https://img.shields.io/github/v/release/ozzy-labs/agentic-bootstrap?include_prereleases&label=release)](https://github.com/ozzy-labs/agentic-bootstrap/releases/latest)
 
 **[English](README.md) | 日本語**
 
@@ -43,7 +43,7 @@
 ## 2. リポジトリ構成
 
 ```
-bootstrap/
+agentic-bootstrap/
 ├── install.sh                      # OS 自動判定で dispatch（Linux → ubuntu, Darwin → macos）
 ├── README.md
 ├── README.ja.md
@@ -79,7 +79,7 @@ bootstrap/
 ```bash
 # 1. zsh セットアップ（推奨：最初に実行）
 curl --proto '=https' --tlsv1.2 -fsSL \
-  https://raw.githubusercontent.com/ozzy-labs/bootstrap/main/install.sh | bash -s -- zsh
+  https://raw.githubusercontent.com/ozzy-labs/agentic-bootstrap/main/install.sh | bash -s -- zsh
 
 # 2. ターミナルを再起動
 exit
@@ -87,7 +87,7 @@ exit
 
 # 3. 開発ツールをセットアップ（mise, 言語環境, Docker, AI CLI, AI パワーツール等）
 curl --proto '=https' --tlsv1.2 -fsSL \
-  https://raw.githubusercontent.com/ozzy-labs/bootstrap/main/install.sh | bash -s -- local
+  https://raw.githubusercontent.com/ozzy-labs/agentic-bootstrap/main/install.sh | bash -s -- local
 
 # 4. インストール済みのものだけ認証を完了
 aws configure      # または aws configure sso
@@ -111,14 +111,14 @@ gemini              # 初回起動時に Google アカウントで認証
 ```bash
 # 一時ファイルにダウンロード
 curl --proto '=https' --tlsv1.2 -fsSL \
-  https://raw.githubusercontent.com/ozzy-labs/bootstrap/main/install.sh \
-  -o /tmp/bootstrap-install.sh
+  https://raw.githubusercontent.com/ozzy-labs/agentic-bootstrap/main/install.sh \
+  -o /tmp/agentic-bootstrap-install.sh
 
 # 内容を確認
-less /tmp/bootstrap-install.sh
+less /tmp/agentic-bootstrap-install.sh
 
 # 実行
-bash /tmp/bootstrap-install.sh local
+bash /tmp/agentic-bootstrap-install.sh local
 ```
 
 ### 4.2 SHA256 でリリース版を検証する
@@ -128,7 +128,7 @@ bash /tmp/bootstrap-install.sh local
 ```bash
 # 特定リリースに固定（v0.1.0 を最新タグに置き換える）
 TAG=v0.1.0
-BASE="https://github.com/ozzy-labs/bootstrap/releases/download/${TAG}"
+BASE="https://github.com/ozzy-labs/agentic-bootstrap/releases/download/${TAG}"
 
 # スクリプトとチェックサムをダウンロード
 curl --proto '=https' --tlsv1.2 -fsSL "${BASE}/install.sh" -o install.sh
@@ -144,8 +144,8 @@ bash install.sh local
 ### 4.3 clone して実行（コントリビュータ / fork 利用者向け）
 
 ```bash
-git clone https://github.com/ozzy-labs/bootstrap.git
-cd bootstrap
+git clone https://github.com/ozzy-labs/agentic-bootstrap.git
+cd agentic-bootstrap
 ./install.sh zsh
 ./install.sh local
 ```
@@ -220,7 +220,7 @@ Ubuntu/Debian 環境（WSL2 + 非 WSL Linux）で zsh + oh-my-zsh + プラグイ
 
 ```bash
 # install.sh 経由で実行（初回セットアップ向け）
-curl -fsSL https://raw.githubusercontent.com/ozzy-labs/bootstrap/main/install.sh | bash -s -- zsh
+curl -fsSL https://raw.githubusercontent.com/ozzy-labs/agentic-bootstrap/main/install.sh | bash -s -- zsh
 
 # clone 済みリポジトリから実行
 ./install.sh zsh
@@ -344,7 +344,7 @@ Ubuntu/Debian 環境（WSL2 + 非 WSL Linux：Ubuntu Server / EC2 / GCE / コン
 
 ```bash
 # install.sh 経由で実行（初回セットアップ向け）
-curl -fsSL https://raw.githubusercontent.com/ozzy-labs/bootstrap/main/install.sh | bash -s -- local
+curl -fsSL https://raw.githubusercontent.com/ozzy-labs/agentic-bootstrap/main/install.sh | bash -s -- local
 
 # clone 済みリポジトリから実行
 ./install.sh local
@@ -641,7 +641,7 @@ SETUP_LOG=/tmp/update.log ./install.sh update
 **6.5.4 出力例**
 
 ```
-🩺 bootstrap doctor を実行中...
+🩺 agentic-bootstrap doctor を実行中...
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 📊 診断結果
@@ -654,7 +654,7 @@ SETUP_LOG=/tmp/update.log ./install.sh update
    ↳ 対処: eval "$(mise activate bash)"  # または zsh
 ✅ [mise-tools] node は mise 管理下 (current: 24.15.0)
 ⚠️  [chezmoi] ドットファイルに drift あり (12 行の差分)
-   ↳ 対処: chezmoi apply --source /path/to/bootstrap/dotfiles
+   ↳ 対処: chezmoi apply --source /path/to/agentic-bootstrap/dotfiles
 
 サマリー: ✅ 11  ⚠️  2  ❌ 0
 ```
@@ -778,4 +778,4 @@ cat /home/user/setup-local-ubuntu-20250109-123456.log
 
 ## 9. 変更履歴
 
-プロジェクトの変更履歴は [CHANGELOG.md](CHANGELOG.md) で自動管理されています（[release-please](https://github.com/googleapis/release-please) が Conventional Commits から生成）。各リリースの詳細は [GitHub Releases](https://github.com/ozzy-labs/bootstrap/releases) を参照してください。
+プロジェクトの変更履歴は [CHANGELOG.md](CHANGELOG.md) で自動管理されています（[release-please](https://github.com/googleapis/release-please) が Conventional Commits から生成）。各リリースの詳細は [GitHub Releases](https://github.com/ozzy-labs/agentic-bootstrap/releases) を参照してください。

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-# bootstrap
+# agentic-bootstrap
 
 **One-shot host setup for AI-agent-driven development — WSL2 / Linux (Ubuntu/Debian-based) / macOS, Dev Container or direct host use**
 
-[![Lint](https://github.com/ozzy-labs/bootstrap/actions/workflows/lint.yaml/badge.svg)](https://github.com/ozzy-labs/bootstrap/actions/workflows/lint.yaml)
-[![Unit](https://github.com/ozzy-labs/bootstrap/actions/workflows/test-unit.yaml/badge.svg)](https://github.com/ozzy-labs/bootstrap/actions/workflows/test-unit.yaml)
-[![Smoke](https://github.com/ozzy-labs/bootstrap/actions/workflows/test-smoke.yaml/badge.svg)](https://github.com/ozzy-labs/bootstrap/actions/workflows/test-smoke.yaml)
-[![Integration](https://github.com/ozzy-labs/bootstrap/actions/workflows/test-integration.yaml/badge.svg)](https://github.com/ozzy-labs/bootstrap/actions/workflows/test-integration.yaml)
-[![License: MIT](https://img.shields.io/github/license/ozzy-labs/bootstrap)](LICENSE)
-[![Latest Release](https://img.shields.io/github/v/release/ozzy-labs/bootstrap?include_prereleases&label=release)](https://github.com/ozzy-labs/bootstrap/releases/latest)
+[![Lint](https://github.com/ozzy-labs/agentic-bootstrap/actions/workflows/lint.yaml/badge.svg)](https://github.com/ozzy-labs/agentic-bootstrap/actions/workflows/lint.yaml)
+[![Unit](https://github.com/ozzy-labs/agentic-bootstrap/actions/workflows/test-unit.yaml/badge.svg)](https://github.com/ozzy-labs/agentic-bootstrap/actions/workflows/test-unit.yaml)
+[![Smoke](https://github.com/ozzy-labs/agentic-bootstrap/actions/workflows/test-smoke.yaml/badge.svg)](https://github.com/ozzy-labs/agentic-bootstrap/actions/workflows/test-smoke.yaml)
+[![Integration](https://github.com/ozzy-labs/agentic-bootstrap/actions/workflows/test-integration.yaml/badge.svg)](https://github.com/ozzy-labs/agentic-bootstrap/actions/workflows/test-integration.yaml)
+[![License: MIT](https://img.shields.io/github/license/ozzy-labs/agentic-bootstrap)](LICENSE)
+[![Latest Release](https://img.shields.io/github/v/release/ozzy-labs/agentic-bootstrap?include_prereleases&label=release)](https://github.com/ozzy-labs/agentic-bootstrap/releases/latest)
 
 **English | [日本語](README.ja.md)**
 
@@ -43,7 +43,7 @@ A comprehensive collection of shell scripts that bootstraps a development host (
 ## 2. Repository Structure
 
 ```
-bootstrap/
+agentic-bootstrap/
 ├── install.sh                      # OS-aware dispatcher (Linux → linux, Darwin → macos)
 ├── README.md
 ├── README.ja.md
@@ -79,7 +79,7 @@ bootstrap/
 ```bash
 # 1. Set up zsh (recommended first)
 curl --proto '=https' --tlsv1.2 -fsSL \
-  https://raw.githubusercontent.com/ozzy-labs/bootstrap/main/install.sh | bash -s -- zsh
+  https://raw.githubusercontent.com/ozzy-labs/agentic-bootstrap/main/install.sh | bash -s -- zsh
 
 # 2. Restart your terminal
 exit
@@ -87,7 +87,7 @@ exit
 
 # 3. Set up development tools (mise, languages, Docker, AI CLIs, AI power tools, ...)
 curl --proto '=https' --tlsv1.2 -fsSL \
-  https://raw.githubusercontent.com/ozzy-labs/bootstrap/main/install.sh | bash -s -- local
+  https://raw.githubusercontent.com/ozzy-labs/agentic-bootstrap/main/install.sh | bash -s -- local
 
 # 4. Complete required authentications (for what you installed)
 aws configure      # or: aws configure sso
@@ -111,14 +111,14 @@ If you prefer to read the script before running it, download first and review:
 ```bash
 # Download to a temp file
 curl --proto '=https' --tlsv1.2 -fsSL \
-  https://raw.githubusercontent.com/ozzy-labs/bootstrap/main/install.sh \
-  -o /tmp/bootstrap-install.sh
+  https://raw.githubusercontent.com/ozzy-labs/agentic-bootstrap/main/install.sh \
+  -o /tmp/agentic-bootstrap-install.sh
 
 # Review the contents
-less /tmp/bootstrap-install.sh
+less /tmp/agentic-bootstrap-install.sh
 
 # Run it
-bash /tmp/bootstrap-install.sh local
+bash /tmp/agentic-bootstrap-install.sh local
 ```
 
 ### 4.2 Verify a release with SHA256
@@ -128,7 +128,7 @@ For pinned, reproducible installs, use a tagged release. Each GitHub Release shi
 ```bash
 # Pin to a specific release (replace v0.1.0 with the latest tag)
 TAG=v0.1.0
-BASE="https://github.com/ozzy-labs/bootstrap/releases/download/${TAG}"
+BASE="https://github.com/ozzy-labs/agentic-bootstrap/releases/download/${TAG}"
 
 # Download both the script and its checksum
 curl --proto '=https' --tlsv1.2 -fsSL "${BASE}/install.sh" -o install.sh
@@ -144,8 +144,8 @@ bash install.sh local
 ### 4.3 Clone-and-run (for contributors / forkers)
 
 ```bash
-git clone https://github.com/ozzy-labs/bootstrap.git
-cd bootstrap
+git clone https://github.com/ozzy-labs/agentic-bootstrap.git
+cd agentic-bootstrap
 ./install.sh zsh
 ./install.sh local
 ```
@@ -220,7 +220,7 @@ You can run it either through `install.sh` or directly via `scripts/setup-zsh-li
 
 ```bash
 # Via install.sh (recommended for first-time setup)
-curl -fsSL https://raw.githubusercontent.com/ozzy-labs/bootstrap/main/install.sh | bash -s -- zsh
+curl -fsSL https://raw.githubusercontent.com/ozzy-labs/agentic-bootstrap/main/install.sh | bash -s -- zsh
 
 # Basic execution from a cloned repository
 ./install.sh zsh
@@ -344,7 +344,7 @@ You can run it either through `install.sh` or directly via `scripts/setup-local-
 
 ```bash
 # Via install.sh (recommended for first-time setup)
-curl -fsSL https://raw.githubusercontent.com/ozzy-labs/bootstrap/main/install.sh | bash -s -- local
+curl -fsSL https://raw.githubusercontent.com/ozzy-labs/agentic-bootstrap/main/install.sh | bash -s -- local
 
 # Basic execution from a cloned repository
 ./install.sh local
@@ -641,7 +641,7 @@ Each non-`✅` finding is paired with a copy-paste-ready fix hint. The Doctor ne
 **6.5.4 Sample Output**
 
 ```
-🩺 bootstrap doctor を実行中...
+🩺 agentic-bootstrap doctor を実行中...
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 📊 診断結果
@@ -654,7 +654,7 @@ Each non-`✅` finding is paired with a copy-paste-ready fix hint. The Doctor ne
    ↳ 対処: eval "$(mise activate bash)"  # または zsh
 ✅ [mise-tools] node は mise 管理下 (current: 24.15.0)
 ⚠️  [chezmoi] ドットファイルに drift あり (12 行の差分)
-   ↳ 対処: chezmoi apply --source /path/to/bootstrap/dotfiles
+   ↳ 対処: chezmoi apply --source /path/to/agentic-bootstrap/dotfiles
 
 サマリー: ✅ 11  ⚠️  2  ❌ 0
 ```
@@ -777,4 +777,4 @@ For detailed review process, see:
 
 ## 9. Changelog
 
-The changelog is auto-managed in [CHANGELOG.md](CHANGELOG.md) by [release-please](https://github.com/googleapis/release-please) from Conventional Commits. Per-release details are published on [GitHub Releases](https://github.com/ozzy-labs/bootstrap/releases).
+The changelog is auto-managed in [CHANGELOG.md](CHANGELOG.md) by [release-please](https://github.com/googleapis/release-please) from Conventional Commits. Per-release details are published on [GitHub Releases](https://github.com/ozzy-labs/agentic-bootstrap/releases).

--- a/docs/adr/ADR-0004-stay-bash-and-publish-readiness.md
+++ b/docs/adr/ADR-0004-stay-bash-and-publish-readiness.md
@@ -8,10 +8,10 @@ ADR-0001 を継承・補強する。
 
 ## コンテキスト
 
-パブリック公開（OSS としての発信）に向けて、`bootstrap` の実装言語と配布形式を再検討する必要が生じた。具体的には以下の選択肢が候補に挙がった。
+パブリック公開（OSS としての発信）に向けて、`agentic-bootstrap` の実装言語と配布形式を再検討する必要が生じた。具体的には以下の選択肢が候補に挙がった。
 
 1. **Bash 維持**: 現行の `install.sh` + `scripts/setup-local-*.sh` を Bash のまま継続し、保守性は責務分割で解決する。
-2. **TypeScript + npm パッケージ化**: `@ozzylabs/bootstrap` として npm に publish し、`npx` 経由で実行させる。
+2. **TypeScript + npm パッケージ化**: `@ozzylabs/agentic-bootstrap` として npm に publish し、`npx` 経由で実行させる。
 3. **Bun 単一バイナリ**: TypeScript で書き、Bun で単一バイナリにコンパイルして GitHub Release で配布する。
 4. **Deno**: 同様に Deno の `deno install` ベースで配布する。
 
@@ -36,7 +36,7 @@ ADR-0001 を継承・補強する。
 
 ### 1. 依存最小化（ADR-0001 の継承）
 
-bootstrap は **ランタイム導入前** に実行されるツールである。Node.js 自身に依存させることは、依存解決の循環構造（`install.sh` で Node を入れた後に `npx` でメインロジックを呼ぶ）を生み、ツールの本質的役割と矛盾する。
+agentic-bootstrap は **ランタイム導入前** に実行されるツールである。Node.js 自身に依存させることは、依存解決の循環構造（`install.sh` で Node を入れた後に `npx` でメインロジックを呼ぶ）を生み、ツールの本質的役割と矛盾する。
 
 ### 2. 業界標準
 

--- a/install.sh
+++ b/install.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 readonly REPO_OWNER="ozzy-labs"
-readonly REPO_NAME="bootstrap"
+readonly REPO_NAME="agentic-bootstrap"
 readonly DEFAULT_REF="${BOOTSTRAP_REF:-main}"
 
 # OS 判定: install.sh local / all が dispatch 先のスクリプトを切り替えるために使う
@@ -18,7 +18,7 @@ usage() {
   cat <<'EOF'
 Usage:
   ./install.sh [zsh|local|all|update|doctor] [--ref <git-ref>] [--auto|--interactive]
-  curl -fsSL https://raw.githubusercontent.com/ozzy-labs/bootstrap/main/install.sh | bash -s -- [zsh|local|all|update|doctor] [--ref <git-ref>] [--auto|--interactive]
+  curl -fsSL https://raw.githubusercontent.com/ozzy-labs/agentic-bootstrap/main/install.sh | bash -s -- [zsh|local|all|update|doctor] [--ref <git-ref>] [--auto|--interactive]
 
 Commands:
   zsh     Run scripts/setup-zsh-linux.sh (Linux/WSL only; macOS skips with a notice)

--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -1,7 +1,7 @@
 extends:
   - lefthook-base.yaml
 
-# Bootstrap-specific overrides on top of the shared base from commons.
+# agentic-bootstrap specific overrides on top of the shared base from commons.
 #
 # lefthook's extends merge has base-wins semantics: when a command key exists
 # in both base and local, the base entry wins (verified with lefthook 2.1.6
@@ -10,12 +10,12 @@ extends:
 #
 # Unpinning lefthook-base.yaml in .commons/sync.yaml lets future commons
 # improvements (e.g. ozzy-labs/commons#117 mise-exec wrapping) flow in
-# automatically; bootstrap-specific behavior stays here.
+# automatically; agentic-bootstrap specific behavior stays here.
 pre-commit:
   commands:
-    # Substitute base `shell` with severity=warning. Bootstrap shell scripts
-    # intentionally produce SC2088 (tilde-in-log) and other info-level
-    # findings. See ozzy-labs/bootstrap#6.
+    # Substitute base `shell` with severity=warning. agentic-bootstrap shell
+    # scripts intentionally produce SC2088 (tilde-in-log) and other info-level
+    # findings. See ozzy-labs/agentic-bootstrap#6.
     #
     # `run:` here is a stub; lefthook validate requires it to be a string,
     # but at execution time base's `run:` wins via extends merge — and `skip`
@@ -23,15 +23,15 @@ pre-commit:
     shell:
       run: "true"
       skip: true
-    bootstrap-shell:
+    agentic-bootstrap-shell:
       glob: "**/*.sh"
       run: mise exec -- shfmt -w {staged_files} && mise exec -- shellcheck --severity=warning {staged_files}
       stage_fixed: true
-    # Substitute base `trivy` with --scanners vuln only. Bootstrap has no
-    # package manifest, so trivy's secret scanner is redundant with gitleaks.
-    # See ozzy-labs/bootstrap#63.
+    # Substitute base `trivy` with --scanners vuln only. agentic-bootstrap
+    # has no package manifest, so trivy's secret scanner is redundant with
+    # gitleaks. See ozzy-labs/agentic-bootstrap#63.
     trivy:
       run: "true"
       skip: true
-    bootstrap-trivy:
+    agentic-bootstrap-trivy:
       run: mise exec -- trivy fs --scanners vuln --exit-code 1 --no-progress .

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,26 +1,26 @@
 {
-  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
-  "release-type": "simple",
-  "packages": {
-    ".": {
-      "package-name": "bootstrap",
-      "changelog-path": "CHANGELOG.md",
-      "include-component-in-tag": false,
-      "draft": false,
-      "prerelease": false
-    }
-  },
-  "include-v-in-tag": true,
-  "changelog-sections": [
-    { "type": "feat", "section": "Features", "hidden": false },
-    { "type": "fix", "section": "Bug Fixes", "hidden": false },
-    { "type": "perf", "section": "Performance Improvements", "hidden": false },
-    { "type": "refactor", "section": "Refactoring", "hidden": false },
-    { "type": "docs", "section": "Documentation", "hidden": false },
-    { "type": "build", "section": "Build System", "hidden": false },
-    { "type": "ci", "section": "Continuous Integration", "hidden": false },
-    { "type": "test", "section": "Tests", "hidden": false },
-    { "type": "chore", "section": "Miscellaneous", "hidden": true },
-    { "type": "style", "section": "Styling", "hidden": true }
-  ]
+	"$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+	"release-type": "simple",
+	"packages": {
+		".": {
+			"package-name": "agentic-bootstrap",
+			"changelog-path": "CHANGELOG.md",
+			"include-component-in-tag": false,
+			"draft": false,
+			"prerelease": false
+		}
+	},
+	"include-v-in-tag": true,
+	"changelog-sections": [
+		{ "type": "feat", "section": "Features", "hidden": false },
+		{ "type": "fix", "section": "Bug Fixes", "hidden": false },
+		{ "type": "perf", "section": "Performance Improvements", "hidden": false },
+		{ "type": "refactor", "section": "Refactoring", "hidden": false },
+		{ "type": "docs", "section": "Documentation", "hidden": false },
+		{ "type": "build", "section": "Build System", "hidden": false },
+		{ "type": "ci", "section": "Continuous Integration", "hidden": false },
+		{ "type": "test", "section": "Tests", "hidden": false },
+		{ "type": "chore", "section": "Miscellaneous", "hidden": true },
+		{ "type": "style", "section": "Styling", "hidden": true }
+	]
 }

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -55,7 +55,7 @@ doctor_record() {
 # 診断実行
 # ========================================
 
-echo "🩺 bootstrap doctor を実行中..."
+echo "🩺 agentic-bootstrap doctor を実行中..."
 echo ""
 
 check_system_tools

--- a/scripts/lib/doctor-checks.sh
+++ b/scripts/lib/doctor-checks.sh
@@ -7,7 +7,7 @@
 # 前提: SCRIPT_DIR が定義されていること（リポジトリ内 dotfiles の解決用）。
 
 # 1. システム基本ツールの検証
-# bootstrap が動くために最低限必要な CLI が揃っているかをチェック
+# agentic-bootstrap が動くために最低限必要な CLI が揃っているかをチェック
 check_system_tools() {
   local tools=(curl git unzip xz tar)
   local tool

--- a/scripts/lib/install-basic-cli.sh
+++ b/scripts/lib/install-basic-cli.sh
@@ -51,7 +51,7 @@ install_basic_cli_tools() {
   # unzip （AWS CLI 等に必要）
   apt_install_or_upgrade "unzip" "unzip" "unzip"
 
-  # NOTE: wslu / wslview は WSL2 専用ユーティリティのため、bootstrap の
+  # NOTE: wslu / wslview は WSL2 専用ユーティリティのため、agentic-bootstrap の
   # 共通フローからは除外している。WSL2 上で `wslview` が必要な場合は
   # 各 WSL ディストリで手動インストールする想定:
   #   sudo apt-get install -y wslu  # Ubuntu 22.04 / 24.04 では標準リポジトリに含まれる

--- a/scripts/setup-local-linux.sh
+++ b/scripts/setup-local-linux.sh
@@ -515,7 +515,7 @@ if command -v git &>/dev/null; then
   echo "✅ Git 設定完了"
 fi
 
-# NOTE: BROWSER=wslview の自動設定は WSL2 専用のため bootstrap の共通フローからは
+# NOTE: BROWSER=wslview の自動設定は WSL2 専用のため agentic-bootstrap の共通フローからは
 # 除外している。WSL2 上で必要な場合は wslu インストール後に手動で追加する:
 #   echo 'export BROWSER=wslview' >> ~/.zshrc
 

--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -49,7 +49,7 @@ for version in "${VERSIONS[@]}"; do
   printf '🐳 Testing against ubuntu:%s\n' "$version"
   printf '═══════════════════════════════════════════\n'
 
-  tag="bootstrap-test:${version//[^A-Za-z0-9._-]/-}"
+  tag="agentic-bootstrap-test:${version//[^A-Za-z0-9._-]/-}"
 
   if ! docker build \
     --build-arg "UBUNTU_VERSION=${version}" \


### PR DESCRIPTION
Closes #132

## Summary

Rename `bootstrap` → `agentic-bootstrap` across in-repo references, aligned with the upcoming GitHub repository rename.

## Changes

- `install.sh`: `REPO_NAME` constant + usage URL
- `README.md` / `README.ja.md`: title, badges, install URLs, repo URLs, directory tree, clone commands, doctor display, dotfiles example path
- `release-please-config.json`: `package-name` → `agentic-bootstrap`
- `lefthook.yaml`: self-referenced issue numbers and command keys (`bootstrap-shell` / `bootstrap-trivy` → `agentic-bootstrap-*`)
- `.github/workflows/{canary,test-integration}.yaml`: Docker tag prefixes
- `tests/integration/run.sh`: Docker tag prefix
- `docs/adr/ADR-0004-*.md`: project-name self-references
- `scripts/doctor.sh` / `scripts/lib/*.sh` / `scripts/setup-local-linux.sh`: user-facing display string + comments

## Out of scope (intentional)

- `CHANGELOG.md` historical entries — auto-managed by release-please; the GitHub repo rename redirect keeps existing PR/commit links live.
- `lefthook-base.yaml` — synced from commons; the comment update will arrive via the next commons sync (see handbook-side issue covering 11 repos).
- `BOOTSTRAP_REF` / `BOOTSTRAP_ASSUME_YES` env vars — public API; renaming would be a breaking change and is not in this issue's scope.

## Test plan

- [x] `bash -n` clean on touched shell scripts
- [x] `markdownlint-cli2 --fix` clean
- [x] `yamlfmt` + `yamllint -c .yamllint.yaml` clean
- [x] `shfmt -w` + `shellcheck` (info-level findings are pre-existing)
- [x] `biome check` clean on `release-please-config.json`
- [x] pre-commit hook (lefthook) green
- [ ] CI: lint / unit / smoke / integration on PR
- [ ] Repo rename on GitHub Settings (manual, post-merge)