### PR TITLE
refactor: rename BOOTSTRAP_* env vars to AGENTIC_BOOTSTRAP_* with fallback

### DIFF
--- a/.github/workflows/canary.yaml
+++ b/.github/workflows/canary.yaml
@@ -117,7 +117,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
-      BOOTSTRAP_ASSUME_YES: "1"
+      AGENTIC_BOOTSTRAP_ASSUME_YES: "1"
       CI: "true"
       # コンテナ専用の重量ツールはランナー上では不要なので最小化
       INSTALL_CONTAINER: "0"
@@ -190,7 +190,7 @@ jobs:
     runs-on: macos-latest
     timeout-minutes: 30
     env:
-      BOOTSTRAP_ASSUME_YES: "1"
+      AGENTIC_BOOTSTRAP_ASSUME_YES: "1"
       CI: "true"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/README.ja.md
+++ b/README.ja.md
@@ -554,7 +554,7 @@ SETUP_LOG=/tmp/setup.log ./install.sh local
 ./scripts/setup-local-macos.sh
 
 # 非対話モード（CI / スクリプト実行）
-BOOTSTRAP_ASSUME_YES=1 ./scripts/setup-local-macos.sh
+AGENTIC_BOOTSTRAP_ASSUME_YES=1 ./scripts/setup-local-macos.sh
 ```
 
 **6.3.4 注意事項**

--- a/README.md
+++ b/README.md
@@ -554,7 +554,7 @@ macOS counterpart to `setup-local-linux.sh`, intentionally lighter-weight: focus
 ./scripts/setup-local-macos.sh
 
 # Non-interactive (CI / scripted)
-BOOTSTRAP_ASSUME_YES=1 ./scripts/setup-local-macos.sh
+AGENTIC_BOOTSTRAP_ASSUME_YES=1 ./scripts/setup-local-macos.sh
 ```
 
 **6.3.4 Notes**

--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 readonly REPO_OWNER="ozzy-labs"
 readonly REPO_NAME="agentic-bootstrap"
-readonly DEFAULT_REF="${BOOTSTRAP_REF:-main}"
+readonly DEFAULT_REF="${AGENTIC_BOOTSTRAP_REF:-${BOOTSTRAP_REF:-main}}"
 
 # OS 判定: install.sh local / all が dispatch 先のスクリプトを切り替えるために使う
 detect_os() {
@@ -36,8 +36,9 @@ Options:
   -h, --help       Show this help message
 
 Environment:
-  BOOTSTRAP_REF      Default git ref to download when running remotely
-  SETUP_LOG          Passed through to the underlying setup/update script(s)
+  AGENTIC_BOOTSTRAP_REF  Default git ref to download when running remotely
+                         (legacy: BOOTSTRAP_REF is honored as a fallback)
+  SETUP_LOG              Passed through to the underlying setup/update script(s)
 EOF
 }
 
@@ -142,10 +143,10 @@ main() {
       shift
       ;;
     -y | --auto)
-      export BOOTSTRAP_ASSUME_YES=1
+      export AGENTIC_BOOTSTRAP_ASSUME_YES=1
       ;;
     --interactive)
-      export BOOTSTRAP_ASSUME_YES=0
+      export AGENTIC_BOOTSTRAP_ASSUME_YES=0
       ;;
     -h | --help)
       usage

--- a/scripts/lib/detect.sh
+++ b/scripts/lib/detect.sh
@@ -4,9 +4,10 @@
 # このファイルは source して利用する。直接実行しない。
 
 # 非対話モードかどうかを判定
-# BOOTSTRAP_ASSUME_YES=1 または CI=true でプロンプトを自動回答する
+# AGENTIC_BOOTSTRAP_ASSUME_YES=1（旧名 BOOTSTRAP_ASSUME_YES もフォールバック）
+# または CI=true でプロンプトを自動回答する
 _is_non_interactive() {
-  [ "${BOOTSTRAP_ASSUME_YES:-0}" = "1" ] || [ "${CI:-}" = "true" ]
+  [ "${AGENTIC_BOOTSTRAP_ASSUME_YES:-${BOOTSTRAP_ASSUME_YES:-0}}" = "1" ] || [ "${CI:-}" = "true" ]
 }
 
 # /etc/os-release を読み Ubuntu/Debian 系かを判定

--- a/scripts/lib/prompts.sh
+++ b/scripts/lib/prompts.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # scripts/lib/prompts.sh
-# 対話プロンプトヘルパー。非対話モード（CI / BOOTSTRAP_ASSUME_YES）では自動応答する。
+# 対話プロンプトヘルパー。非対話モード（CI / AGENTIC_BOOTSTRAP_ASSUME_YES、旧名 BOOTSTRAP_ASSUME_YES）では自動応答する。
 # このファイルは source して利用する。前提: lib/detect.sh が事前に source されていること。
 
 # [Y/n] プロンプト（既定 Y）を処理し、REPLY に結果を設定する

--- a/scripts/setup-local-macos.sh
+++ b/scripts/setup-local-macos.sh
@@ -38,9 +38,10 @@ MISE_BIN="$HOME/.local/bin/mise"
 # ========================================
 
 # 非対話モードかどうかを判定
-# BOOTSTRAP_ASSUME_YES=1 または CI=true でプロンプトを自動回答する
+# AGENTIC_BOOTSTRAP_ASSUME_YES=1（旧名 BOOTSTRAP_ASSUME_YES もフォールバック）
+# または CI=true でプロンプトを自動回答する
 _is_non_interactive() {
-  [ "${BOOTSTRAP_ASSUME_YES:-0}" = "1" ] || [ "${CI:-}" = "true" ]
+  [ "${AGENTIC_BOOTSTRAP_ASSUME_YES:-${BOOTSTRAP_ASSUME_YES:-0}}" = "1" ] || [ "${CI:-}" = "true" ]
 }
 
 # パイプ実行時 (curl ... | bash) でも対話プロンプトが動作するよう、

--- a/scripts/setup-zsh-linux.sh
+++ b/scripts/setup-zsh-linux.sh
@@ -18,9 +18,10 @@ INSTALL_HISTORY_SUBSTRING_SEARCH=1
 # ========================================
 
 # 非対話モードかどうかを判定
-# BOOTSTRAP_ASSUME_YES=1 または CI=true でプロンプトを自動回答する
+# AGENTIC_BOOTSTRAP_ASSUME_YES=1（旧名 BOOTSTRAP_ASSUME_YES もフォールバック）
+# または CI=true でプロンプトを自動回答する
 _is_non_interactive() {
-  [ "${BOOTSTRAP_ASSUME_YES:-0}" = "1" ] || [ "${CI:-}" = "true" ]
+  [ "${AGENTIC_BOOTSTRAP_ASSUME_YES:-${BOOTSTRAP_ASSUME_YES:-0}}" = "1" ] || [ "${CI:-}" = "true" ]
 }
 
 # パイプ実行時 (curl ... | bash) でも対話プロンプトが動作するよう、

--- a/tests/integration/entrypoint.sh
+++ b/tests/integration/entrypoint.sh
@@ -94,7 +94,7 @@ printf '━━━━━━━━━━━━━━━━━━━━━━━━
 # unbound variable で死んでいないことだけを検証する（set -u 違反の検出）。
 PIPE_INSTALL_LOG="/tmp/pipe-install.log"
 cat /workspace/install.sh |
-  BOOTSTRAP_REF="non-existent-ref-for-trap-regression-$$" bash -s -- local \
+  AGENTIC_BOOTSTRAP_REF="non-existent-ref-for-trap-regression-$$" bash -s -- local \
     >"$PIPE_INSTALL_LOG" 2>&1 || true
 if grep -qE "unbound variable" "$PIPE_INSTALL_LOG"; then
   echo "❌ install.sh emitted 'unbound variable' under pipe execution:"

--- a/tests/unit/prompts.bats
+++ b/tests/unit/prompts.bats
@@ -24,16 +24,25 @@ setup() {
 
 @test "_prompt_default_yes: sets REPLY=Y and prints suffix in non-interactive mode" {
   CI=true
-  unset BOOTSTRAP_ASSUME_YES
+  unset AGENTIC_BOOTSTRAP_ASSUME_YES BOOTSTRAP_ASSUME_YES
   REPLY=""
   _prompt_default_yes "Continue? [Y/n]: " >"$OUT_FILE"
   [ "$REPLY" = "Y" ]
   grep -q "Y (non-interactive)" "$OUT_FILE"
 }
 
-@test "_prompt_default_yes: respects BOOTSTRAP_ASSUME_YES=1" {
+@test "_prompt_default_yes: respects AGENTIC_BOOTSTRAP_ASSUME_YES=1" {
+  AGENTIC_BOOTSTRAP_ASSUME_YES=1
+  unset BOOTSTRAP_ASSUME_YES CI
+  REPLY=""
+  _prompt_default_yes "Continue? [Y/n]: " >"$OUT_FILE"
+  [ "$REPLY" = "Y" ]
+  grep -q "Y (non-interactive)" "$OUT_FILE"
+}
+
+@test "_prompt_default_yes: legacy BOOTSTRAP_ASSUME_YES=1 still works (fallback)" {
+  unset AGENTIC_BOOTSTRAP_ASSUME_YES CI
   BOOTSTRAP_ASSUME_YES=1
-  unset CI
   REPLY=""
   _prompt_default_yes "Continue? [Y/n]: " >"$OUT_FILE"
   [ "$REPLY" = "Y" ]
@@ -46,16 +55,24 @@ setup() {
 
 @test "_prompt_default_no: sets REPLY=N and prints suffix in non-interactive mode" {
   CI=true
-  unset BOOTSTRAP_ASSUME_YES
+  unset AGENTIC_BOOTSTRAP_ASSUME_YES BOOTSTRAP_ASSUME_YES
   REPLY=""
   _prompt_default_no "Continue? [y/N]: " >"$OUT_FILE"
   [ "$REPLY" = "N" ]
   grep -q "N (non-interactive)" "$OUT_FILE"
 }
 
-@test "_prompt_default_no: respects BOOTSTRAP_ASSUME_YES=1" {
+@test "_prompt_default_no: respects AGENTIC_BOOTSTRAP_ASSUME_YES=1" {
+  AGENTIC_BOOTSTRAP_ASSUME_YES=1
+  unset BOOTSTRAP_ASSUME_YES CI
+  REPLY=""
+  _prompt_default_no "Continue? [y/N]: " >"$OUT_FILE"
+  [ "$REPLY" = "N" ]
+}
+
+@test "_prompt_default_no: legacy BOOTSTRAP_ASSUME_YES=1 still works (fallback)" {
+  unset AGENTIC_BOOTSTRAP_ASSUME_YES CI
   BOOTSTRAP_ASSUME_YES=1
-  unset CI
   REPLY=""
   _prompt_default_no "Continue? [y/N]: " >"$OUT_FILE"
   [ "$REPLY" = "N" ]

--- a/tests/unit/shell-config.bats
+++ b/tests/unit/shell-config.bats
@@ -30,31 +30,48 @@ setup() {
 # _is_non_interactive
 # ------------------------------------------------------------------
 
-@test "_is_non_interactive: returns true when BOOTSTRAP_ASSUME_YES=1" {
-  BOOTSTRAP_ASSUME_YES=1
-  unset CI
+@test "_is_non_interactive: returns true when AGENTIC_BOOTSTRAP_ASSUME_YES=1" {
+  AGENTIC_BOOTSTRAP_ASSUME_YES=1
+  unset BOOTSTRAP_ASSUME_YES CI
   run _is_non_interactive
   [ "$status" -eq 0 ]
 }
 
 @test "_is_non_interactive: returns true when CI=true" {
-  unset BOOTSTRAP_ASSUME_YES
+  unset AGENTIC_BOOTSTRAP_ASSUME_YES BOOTSTRAP_ASSUME_YES
   CI=true
   run _is_non_interactive
   [ "$status" -eq 0 ]
 }
 
 @test "_is_non_interactive: returns false when neither env is set" {
-  unset BOOTSTRAP_ASSUME_YES CI
+  unset AGENTIC_BOOTSTRAP_ASSUME_YES BOOTSTRAP_ASSUME_YES CI
   run _is_non_interactive
   [ "$status" -ne 0 ]
 }
 
 @test "_is_non_interactive: returns false for other values" {
   # shellcheck disable=SC2034  # 変数は sourced 関数経由で参照される
-  BOOTSTRAP_ASSUME_YES=0
+  AGENTIC_BOOTSTRAP_ASSUME_YES=0
+  unset BOOTSTRAP_ASSUME_YES
   # shellcheck disable=SC2034
   CI=false
+  run _is_non_interactive
+  [ "$status" -ne 0 ]
+}
+
+@test "_is_non_interactive: legacy BOOTSTRAP_ASSUME_YES=1 still triggers non-interactive (fallback)" {
+  unset AGENTIC_BOOTSTRAP_ASSUME_YES CI
+  BOOTSTRAP_ASSUME_YES=1
+  run _is_non_interactive
+  [ "$status" -eq 0 ]
+}
+
+@test "_is_non_interactive: new name takes precedence over legacy name" {
+  # 新名 0 / 旧名 1 → 新名が優先されて非対話モードにならない
+  AGENTIC_BOOTSTRAP_ASSUME_YES=0
+  BOOTSTRAP_ASSUME_YES=1
+  unset CI
   run _is_non_interactive
   [ "$status" -ne 0 ]
 }


### PR DESCRIPTION
## Summary

Closes #135

`BOOTSTRAP_*` 環境変数を `AGENTIC_BOOTSTRAP_*` にリネームし、旧名は param expansion fallback で後方互換を維持する。[ADR-0024](https://github.com/ozzy-labs/handbook/blob/main/adr/0024-rename-bootstrap-to-agentic-bootstrap.md) に基づく brand 整合の最終仕上げ。

- `BOOTSTRAP_REF` → `AGENTIC_BOOTSTRAP_REF`
- `BOOTSTRAP_ASSUME_YES` → `AGENTIC_BOOTSTRAP_ASSUME_YES`

両方設定された場合は新名が優先される (`${AGENTIC_BOOTSTRAP_ASSUME_YES:-${BOOTSTRAP_ASSUME_YES:-0}}` の順)。

## Changes

| File | Change |
| --- | --- |
| `install.sh` | `DEFAULT_REF` を fallback 付きに / Usage 文を更新 / `--auto`・`--interactive` の export を新名に |
| `scripts/lib/detect.sh` | `_is_non_interactive` を fallback 付きに |
| `scripts/lib/prompts.sh` | コメントの env 変数名を更新 |
| `scripts/setup-zsh-linux.sh` / `scripts/setup-local-macos.sh` | `_is_non_interactive` を fallback 付きに |
| `tests/unit/shell-config.bats` / `tests/unit/prompts.bats` | 新名テストに更新 + 旧名 fallback / 新名優先のケース追加 |
| `tests/integration/entrypoint.sh` | trap 回帰テストの `BOOTSTRAP_REF` を新名に |
| `.github/workflows/canary.yaml` | canary-ubuntu-native / canary-macos の env を新名に |
| `README.md` / `README.ja.md` | 使用例を新名に |

## Deprecation 戦略

- 旧名は 2 minor リリース以上 fallback でサポート継続
- README / docs では新名のみを記載
- 削除時は別 ADR + breaking change リリース

## Test plan

- [x] 既存 bats テストが新名で全件パス（23/23）
- [x] 旧名のみ設定時に fallback が機能（新規テストケース）
- [x] 新名と旧名が両方設定時、新名が優先（新規テストケース）
- [ ] CI canary workflow が `AGENTIC_BOOTSTRAP_ASSUME_YES` で動作（マージ後の週次実行で確認）
- [x] shellcheck / shfmt / yamllint / actionlint / markdownlint / commitlint クリーン

## 関連

- [handbook ADR-0024](https://github.com/ozzy-labs/handbook/blob/main/adr/0024-rename-bootstrap-to-agentic-bootstrap.md)
- ozzy-labs/bootstrap#132 (repo rename)

🤖 Generated with [Claude Code](https://claude.com/claude-code)