### PR TITLE
chore(release): force next release to v0.2.0

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,7 +7,8 @@
 			"changelog-path": "CHANGELOG.md",
 			"include-component-in-tag": false,
 			"draft": false,
-			"prerelease": false
+			"prerelease": false,
+			"release-as": "0.2.0"
 		}
 	},
 	"include-v-in-tag": true,


### PR DESCRIPTION
## Summary

`release-please-config.json` に `"release-as": "0.2.0"` を追加し、次のリリースを **v0.2.0** に固定する。

## 背景

bootstrap → agentic-bootstrap のブランド整合 (#133, #134, #136) を release で可視化するため、SemVer のシグナリング観点から minor バンプにする。#136 自身は env var rename を fallback 付きで non-breaking に実装しているため技術的には patch でも成立するが、ブランド境界を release タイトルで明示する判断。

## 影響

- 本 PR がマージされると、release-please は既存の release PR #137 を **0.2.0 に更新**する（前例 #94 → #96 と同じ挙動）
- v0.2.0 リリース後、SemVer の通常運用に戻すため `release-as` フィールドは **手動で削除する必要がある**（#103 の cleanup パターンを踏襲）

## Follow-up

v0.2.0 リリース後に `release-as` を削除する chore PR を切る。

## Test plan

- [x] commitlint / lefthook hooks クリーン
- [ ] マージ後、release-please workflow が PR #137 を 0.2.0 に更新することを確認