### PR TITLE
chore(release): drop release-as override after v0.2.0

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -7,8 +7,7 @@
 			"changelog-path": "CHANGELOG.md",
 			"include-component-in-tag": false,
 			"draft": false,
-			"prerelease": false,
-			"release-as": "0.2.0"
+			"prerelease": false
 		}
 	},
 	"include-v-in-tag": true,


### PR DESCRIPTION
## Summary

`release-please-config.json` から `"release-as": "0.2.0"` を削除し、SemVer の通常バンプ運用に戻す。

## 背景

#138 で v0.2.0 を強制リリースする ためにフィールドを追加した。v0.2.0 は無事公開済み (https://github.com/ozzy-labs/agentic-bootstrap/releases/tag/v0.2.0) のため、削除しないと release-please が今後も 0.2.0 を提案し続ける。

v0.1.0 リリース後の同形 cleanup PR は #103。

## Test plan

- [x] commitlint / lefthook hooks クリーン
- [ ] マージ後、release-please workflow が次の release PR で `manifest 0.2.0 → 0.2.1 (or 0.3.0)` を提案することを確認（次の feat/fix 等の commit 投入時）