### PR TITLE
feat(install): add zellij as opt-in multiplexer

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -63,7 +63,7 @@ agentic-bootstrap/
 - 🐍 **Python エコシステム** - mise 管理の Python + uv（パッケージ・venv・CLI ツール）
 - ☁️ **クラウド CLI** - AWS CLI v2（デフォルト ON）/ Azure CLI, Google Cloud CLI（opt-in）
 - 🔒 **モダンなシークレット検知** - gitleaks（2026 デファクト、アクティブメンテ）を mise で導入、プロジェクト側の lefthook と連携
-- 🎨 **シェル体験** - zsh + oh-my-zsh + プラグイン（Ubuntu/Debian）、fzf / ripgrep / fd / jq / tree
+- 🎨 **シェル体験** - zsh + oh-my-zsh + プラグイン（Ubuntu/Debian）、fzf / ripgrep / fd / jq / tree（opt-in: zellij multiplexer）
 - 🔄 **ワンショット更新** - `install.sh update` で mise / uv / npm 管理ツールを一括更新
 - 🐧 **Ubuntu LTS 幅広くサポート** - 22.04 / 24.04 を PR / main push で CI 検証、**次期 LTS 26.04 Resolute Raccoon** も週次 canary で先行検証済み。LTS 切替直後も動作する
 - 🍎 **macOS サポート** - 専用 `setup-local-macos.sh` で同じ mise を入口にしたフローを提供。週次 canary で `macos-latest` を検証
@@ -303,19 +303,21 @@ Ubuntu/Debian 環境（WSL2 + 非 WSL Linux：Ubuntu Server / EC2 / GCE / コン
    - **AWS CLI v2** - AWS リソース操作（デフォルト ON）
    - **Azure CLI** - Microsoft Azure リソース操作（opt-in）
    - **Google Cloud CLI** - Google Cloud Platform リソース操作（opt-in）
-9. **AI エージェント CLI**（個別選択可）
-   - **Claude Code** - Claude AI との対話型開発ツール
-   - **Codex CLI** - OpenAI Codex CLI（コード生成AI）
-   - **GitHub Copilot CLI** - GitHub Copilot コーディングエージェント（ターミナル版）
-   - **Gemini CLI** - Google Gemini AI エージェント（ターミナル版）
-   - マルチエージェント対応: `.agents/skills/`（Agent Skills 標準）に共通スキル、`AGENTS.md` を共通エントリーポイント、`.claude/skills/` に Claude Code overlay
-10. **AI パワーツール**（エージェントの能力強化）
+9. **Terminal multiplexer**（opt-in）
+   - **Zellij**（mise 経由）- モダンなターミナルマルチプレクサ（opt-in。`INSTALL_ZELLIJ=1` または対話セレクタで選択）
+10. **AI エージェント CLI**（個別選択可）
+    - **Claude Code** - Claude AI との対話型開発ツール
+    - **Codex CLI** - OpenAI Codex CLI（コード生成AI）
+    - **GitHub Copilot CLI** - GitHub Copilot コーディングエージェント（ターミナル版）
+    - **Gemini CLI** - Google Gemini AI エージェント（ターミナル版）
+    - マルチエージェント対応: `.agents/skills/`（Agent Skills 標準）に共通スキル、`AGENTS.md` を共通エントリーポイント、`.claude/skills/` に Claude Code overlay
+11. **AI パワーツール**（エージェントの能力強化）
     - **markitdown[all]**（uv tool 経由）- PDF / Word / Excel / PowerPoint / 画像 / 音声 を Markdown に変換
     - **tesseract-ocr** + **tesseract-ocr-jpn**（apt）- OCR 基盤（markitdown の画像/スキャン PDF 対応を有効化）
     - **ffmpeg**（apt）- 音声・動画処理基盤（markitdown の音声転写・動画処理で利用）
     - **ast-grep**（mise 経由）- 構造的（AST ベース）コード検索・置換
     - **yq**（mise 経由）- YAML クエリツール（jq の YAML 版）
-11. **開発補助ツール**
+12. **開発補助ツール**
     - **just** - タスクランナー
     - **zoxide** - ディレクトリジャンプ機能を持つスマートな cd コマンド
     - **shellcheck**（mise 経由）- シェルスクリプトの静的解析（AI 生成スクリプトの品質担保にも有用）
@@ -537,6 +539,7 @@ SETUP_LOG=/tmp/setup.log ./install.sh local
 - **ast-grep / yq**（mise 経由）— AI パワーツール
 - **markitdown[all]**（`uv tool install` 経由）
 - **just / zoxide / shellcheck**（mise 経由）— 開発補助
+- **zellij**（mise 経由）— ターミナルマルチプレクサ（opt-in。`INSTALL_ZELLIJ=1` を設定）
 
 **6.3.2 自動化対象外（macOS では手動）**
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ agentic-bootstrap/
 - 🐍 **Python Ecosystem** - mise-managed Python + uv for packages/venvs/CLI tools
 - ☁️ **Cloud CLIs** - AWS CLI v2 (default) / Azure CLI, Google Cloud CLI (opt-in)
 - 🔒 **Modern Secret Scanning** - gitleaks (2026 de-facto, actively maintained); pair with lefthook per project
-- 🎨 **Shell Experience** - zsh + oh-my-zsh + plugins (Linux), fzf / ripgrep / fd / jq / tree
+- 🎨 **Shell Experience** - zsh + oh-my-zsh + plugins (Linux), fzf / ripgrep / fd / jq / tree (opt-in: zellij multiplexer)
 - 🔄 **One-shot Upgrades** - `install.sh update` batch-refreshes mise/uv/npm-managed tools
 - 🐧 **Linux (Ubuntu/Debian-based) LTS Coverage** - CI-verified on 22.04 + 24.04; canary-tested on **26.04 Resolute Raccoon** (next LTS) so the toolchain continues to work the day 26.04 lands on WSL2
 - 🍎 **macOS Coverage** - Native `setup-local-macos.sh` keeps the same mise-first flow; canary-verified weekly on `macos-latest`
@@ -303,19 +303,21 @@ You can run it either through `install.sh` or directly via `scripts/setup-local-
    - **AWS CLI v2** - AWS resource operations (default-on)
    - **Azure CLI** - Microsoft Azure resource operations (opt-in)
    - **Google Cloud CLI** - Google Cloud Platform resource operations (opt-in)
-9. **AI Agent CLIs** (choose individually)
-   - **Claude Code** - Interactive development tool with Claude AI
-   - **Codex CLI** - OpenAI Codex CLI (code generation AI)
-   - **GitHub Copilot CLI** - GitHub Copilot coding agent for the terminal
-   - **Gemini CLI** - Google Gemini AI agent for the terminal
-   - Multi-agent support: shared skills in `.agents/skills/` (Agent Skills standard), `AGENTS.md` as common entry point, Claude Code overlays in `.claude/skills/`
-10. **AI Power Tools** (boost agent capabilities)
+9. **Terminal Multiplexer** (opt-in)
+   - **Zellij** (via mise) - Modern terminal multiplexer (opt-in; set `INSTALL_ZELLIJ=1` or select interactively)
+10. **AI Agent CLIs** (choose individually)
+    - **Claude Code** - Interactive development tool with Claude AI
+    - **Codex CLI** - OpenAI Codex CLI (code generation AI)
+    - **GitHub Copilot CLI** - GitHub Copilot coding agent for the terminal
+    - **Gemini CLI** - Google Gemini AI agent for the terminal
+    - Multi-agent support: shared skills in `.agents/skills/` (Agent Skills standard), `AGENTS.md` as common entry point, Claude Code overlays in `.claude/skills/`
+11. **AI Power Tools** (boost agent capabilities)
     - **markitdown[all]** (via uv tool) - Converts PDF / Word / Excel / PowerPoint / images / audio into Markdown
     - **tesseract-ocr** + **tesseract-ocr-jpn** (apt) - OCR backend that enables markitdown to read scanned PDFs and images
     - **ffmpeg** (apt) - Audio/video backend for markitdown transcription and video frame extraction
     - **ast-grep** (via mise) - Structural (AST-based) code search and refactor
     - **yq** (via mise) - YAML query tool; the YAML counterpart of jq
-11. **Development Utilities**
+12. **Development Utilities**
     - **just** - Task runner
     - **zoxide** - Smarter cd command with directory jumping
     - **shellcheck** (via mise) - Shell script static analysis (useful for AI-generated scripts too)
@@ -537,6 +539,7 @@ macOS counterpart to `setup-local-linux.sh`, intentionally lighter-weight: focus
 - **ast-grep / yq** (via mise) — AI power tools
 - **markitdown[all]** (via `uv tool install`)
 - **just / zoxide / shellcheck** (via mise) — dev helpers
+- **zellij** (via mise) — terminal multiplexer (opt-in; set `INSTALL_ZELLIJ=1`)
 
 **6.3.2 What Is NOT Installed (manual on macOS)**
 

--- a/scripts/lib/install-multiplexer.sh
+++ b/scripts/lib/install-multiplexer.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# scripts/lib/install-multiplexer.sh
+# Terminal multiplexer (zellij / tmux) のインストール。
+#
+# multiplexer は好みが大きく分かれるため、すべて opt-in（デフォルト OFF）で
+# `INSTALL_*` 環境変数または対話セレクタで明示有効化された場合のみ導入する。
+# zellij は aqua レジストリ経由で mise pinned、tmux は PR2 で追加予定。
+
+# Terminal multiplexer ツールのインストール（opt-in）
+install_multiplexer_tools() {
+  local any_installed=0
+
+  # zellij（mise 経由、aqua バックエンド）
+  if [ "${INSTALL_ZELLIJ:-0}" = "1" ]; then
+    [ "$any_installed" = "0" ] && {
+      echo ""
+      echo "🪟 Terminal multiplexer をインストール中..."
+      any_installed=1
+    }
+
+    ensure_mise_installed || return 1
+    mise_use_global "zellij@0.44.3" "Zellij"
+  fi
+
+  # NOTE: tmux は PR2 で追加予定（Linux 限定 apt インストール + ~/.tmux.conf 直書き）
+
+  # NOTE: 末尾を `[ X = "1" ] && echo` にすると any_installed=0 のとき
+  # 関数が exit 1 を返し、set -e でスクリプト全体が落ちる。明示的に if/then を使う。
+  if [ "$any_installed" = "1" ]; then
+    echo "✅ Terminal multiplexer インストール完了"
+  fi
+}

--- a/scripts/setup-local-linux.sh
+++ b/scripts/setup-local-linux.sh
@@ -48,6 +48,9 @@ INSTALL_GEMINI_CLI="${INSTALL_GEMINI_CLI:-1}"   # Gemini CLI
 # AIパワーツール（エージェントの文書読み込み・検索を強化）
 INSTALL_AI_POWER_TOOLS="${INSTALL_AI_POWER_TOOLS:-1}" # markitdown, tesseract-ocr(+jpn), ffmpeg, ast-grep, yq
 
+# Terminal multiplexer（opt-in）
+INSTALL_ZELLIJ="${INSTALL_ZELLIJ:-0}" # Zellij（opt-in）
+
 # 開発補助ツール
 INSTALL_DEV_TOOLS="${INSTALL_DEV_TOOLS:-1}" # just, zoxide, shellcheck, chezmoi
 
@@ -85,6 +88,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 . "$SCRIPT_DIR/lib/install-container.sh"
 # shellcheck source=lib/install-cloud.sh
 . "$SCRIPT_DIR/lib/install-cloud.sh"
+# shellcheck source=lib/install-multiplexer.sh
+. "$SCRIPT_DIR/lib/install-multiplexer.sh"
 # shellcheck source=lib/install-ai-agents.sh
 . "$SCRIPT_DIR/lib/install-ai-agents.sh"
 # shellcheck source=lib/install-ai-power.sh
@@ -157,6 +162,7 @@ echo "  📦 Node.js環境 - mise, Node.js LTS, pnpm"
 echo "  🐍 Python環境 - mise, Python, uv"
 echo "  🐳 コンテナ / サンドボックスツール - Docker Engine, Docker Compose, bubblewrap"
 echo "  ☁️ クラウドツール - AWS CLI (default) / Azure CLI, Google Cloud CLI (opt-in)"
+echo "  🪟 Terminal multiplexer - zellij (opt-in)"
 echo "  🤖 AIエージェント CLI - Claude Code, Codex CLI, GitHub Copilot CLI, Gemini CLI"
 echo "  🧠 AIパワーツール - markitdown, tesseract-ocr, ffmpeg, ast-grep, yq"
 echo "  🛠️ 開発補助ツール - just, zoxide, shellcheck, chezmoi"
@@ -219,6 +225,12 @@ if [[ ! $INSTALL_ALL =~ ^[Yy]?$ ]]; then
   _prompt_default_no "  Google Cloud CLI をインストールしますか? [y/N]: "
   echo ""
   [[ $REPLY =~ ^[Yy]$ ]] && INSTALL_GCLOUD_CLI=1
+
+  echo ""
+  echo "🪟 Terminal multiplexer:"
+  _prompt_default_no "  zellij をインストールしますか? [y/N]: "
+  echo ""
+  [[ $REPLY =~ ^[Yy]$ ]] && INSTALL_ZELLIJ=1
 
   echo ""
   echo "🤖 AIエージェント CLI:"
@@ -448,8 +460,9 @@ echo "✅ 依存パッケージインストール完了"
 # ========================================
 # 注意: 依存関係の順序で実行されます
 # 1. ビルド → 2. 基本CLI → 3. Git (git, gh) → 4. mise + 言語環境
-# → 5. Git セキュリティ (gitleaks) → 6. コンテナ / サンドボックス → 7. クラウド → 8. AIエージェント
-# → 9. AI パワーツール → 10. 開発補助
+# → 5. Git セキュリティ (gitleaks) → 6. コンテナ / サンドボックス → 7. クラウド
+# → 8. Terminal multiplexer (opt-in) → 9. AIエージェント
+# → 10. AI パワーツール → 11. 開発補助
 
 install_build_tools
 install_basic_cli_tools
@@ -461,6 +474,7 @@ mise_trust_repo_config "$(dirname "$SCRIPT_DIR")"
 install_git_security_tools
 install_container_tools
 install_cloud_tools
+install_multiplexer_tools
 install_ai_tools
 install_ai_power_tools
 install_dev_tools
@@ -602,6 +616,9 @@ echo "  ☁️ クラウドツール:"
 echo "    AWS CLI:        $(aws --version 2>/dev/null || echo '未インストール')"
 echo "    Azure CLI:      $(az --version 2>/dev/null | head -n1 || echo '未インストール')"
 echo "    Google Cloud:   $(gcloud --version 2>/dev/null | head -n1 || echo '未インストール')"
+echo ""
+echo "  🪟 Terminal multiplexer:"
+echo "    Zellij:         $(zellij --version 2>/dev/null || echo '未インストール (opt-in)')"
 echo ""
 echo "  🤖 AIエージェント CLI:"
 echo "    Claude Code:        $(claude --version 2>/dev/null || echo '未インストール')"

--- a/scripts/setup-local-macos.sh
+++ b/scripts/setup-local-macos.sh
@@ -27,6 +27,7 @@ INSTALL_MISE_LANGUAGES="${INSTALL_MISE_LANGUAGES:-1}" # node + pnpm + python + u
 INSTALL_GIT_TOOLS="${INSTALL_GIT_TOOLS:-1}"           # gitleaks（mise 経由）
 INSTALL_AI_POWER_TOOLS="${INSTALL_AI_POWER_TOOLS:-1}" # ast-grep, yq, markitdown
 INSTALL_DEV_TOOLS="${INSTALL_DEV_TOOLS:-1}"           # just, zoxide, shellcheck, chezmoi
+INSTALL_ZELLIJ="${INSTALL_ZELLIJ:-0}"                 # Zellij（opt-in、mise 経由）
 
 # スクリプトのディレクトリ
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -224,6 +225,18 @@ install_ai_power_tools() {
   fi
 }
 
+# Terminal multiplexer（opt-in、mise 経由）
+# zellij は aqua バックエンドで導入。tmux は macOS では自動化対象外（README §6.3.2 参照）。
+install_multiplexer_tools() {
+  [ "${INSTALL_ZELLIJ:-0}" != "1" ] && return
+
+  ensure_mise_installed || return 1
+
+  echo ""
+  echo "🪟 Terminal multiplexer をインストール中..."
+  mise_use_global "zellij@0.44.3" "Zellij"
+}
+
 # 開発補助ツール: just / zoxide / shellcheck / chezmoi（mise）
 install_dev_tools() {
   [ "$INSTALL_DEV_TOOLS" != "1" ] && return
@@ -308,6 +321,7 @@ install_mise_and_languages
 mise_trust_repo_config "$(dirname "$SCRIPT_DIR")"
 install_git_security_tools
 install_ai_power_tools
+install_multiplexer_tools
 install_dev_tools
 
 # ========================================
@@ -340,6 +354,9 @@ echo "  just:           $(_mise_at_home exec just -- just --version 2>/dev/null 
 echo "  zoxide:         $(_mise_at_home exec zoxide -- zoxide --version 2>/dev/null || echo '未インストール')"
 echo "  shellcheck:     $(_mise_at_home exec shellcheck -- shellcheck --version 2>/dev/null | awk '/^version:/{print $2}' || echo '未インストール')"
 echo "  chezmoi:        $(_mise_at_home exec chezmoi -- chezmoi --version 2>/dev/null || echo '未インストール')"
+echo ""
+echo "🪟 Terminal multiplexer:"
+echo "  Zellij:         $(_mise_at_home exec zellij -- zellij --version 2>/dev/null || echo '未インストール (opt-in)')"
 
 echo ""
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"

--- a/tests/integration/assert-tools.sh
+++ b/tests/integration/assert-tools.sh
@@ -62,6 +62,12 @@ if [ "${INSTALL_CONTAINER:-1}" = "1" ]; then
   echo ""
 fi
 
+if [ "${INSTALL_ZELLIJ:-0}" = "1" ]; then
+  echo "🪟 Terminal multiplexer"
+  assert_tool "zellij" zellij --version
+  echo ""
+fi
+
 echo "📌 Basic CLI"
 assert_tool "tree" tree --version
 assert_tool "fzf" fzf --version

--- a/tests/integration/entrypoint.sh
+++ b/tests/integration/entrypoint.sh
@@ -9,6 +9,7 @@ set -eo pipefail
 
 RUN1_LOG="/tmp/run1.log"
 RUN2_LOG="/tmp/run2.log"
+RUN3_LOG="/tmp/run3.log"
 ASSERT_SCRIPT="/workspace/tests/integration/assert-tools.sh"
 
 printf '\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n'
@@ -138,6 +139,26 @@ if grep -qE "unbound variable" "$PIPE_ZSH_LOG"; then
   exit 1
 fi
 echo "✅ setup-zsh-linux.sh completes under pipe execution"
+
+printf '\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n'
+printf '🔵 3rd run — opt-in multiplexer (INSTALL_ZELLIJ=1)\n'
+printf '━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n'
+
+# multiplexer は opt-in なので、既定の 1st / 2nd run では入らない。
+# 3rd run で INSTALL_ZELLIJ=1 を明示して zellij がインストールされ、
+# assert-tools.sh が opt-in アサーションを満たすことを確認する。
+if ! INSTALL_ZELLIJ=1 /workspace/install.sh local 2>&1 | tee "$RUN3_LOG"; then
+  echo "❌ 3rd run (INSTALL_ZELLIJ=1) failed"
+  exit 1
+fi
+assert_no_fatal_errors "$RUN3_LOG" "3rd run"
+
+# shellcheck disable=SC1091
+source "$HOME/.bashrc" || true
+if ! INSTALL_ZELLIJ=1 bash "$ASSERT_SCRIPT"; then
+  echo "❌ Tool assertions failed after 3rd run (INSTALL_ZELLIJ=1)"
+  exit 1
+fi
 
 # NOTE: setup-local-linux.sh の直接 pipe 実行テストは、scripts/lib/*.sh への
 # 責務分割（#88）以降は実装と整合しないため削除した。実環境では


### PR DESCRIPTION
## Summary

Adds **zellij** as an opt-in terminal multiplexer (PR1 of [#148](https://github.com/ozzy-labs/agentic-bootstrap/issues/148)). This PR establishes the new "🪟 Terminal multiplexer" category that PR2 will extend with tmux.

- Adds `INSTALL_ZELLIJ` flag (default `0`) to both Linux and macOS setup scripts
- New `scripts/lib/install-multiplexer.sh` with `install_multiplexer_tools()` function (mise `aqua:zellij-org/zellij@0.44.3`)
- Interactive selector entry between cloud tools and AI agents (Linux)
- README updates: Features line, §6.2.1 (Linux installed tools), §6.3.1 (macOS installed tools)
- Integration test: opt-in zellij assertion in `assert-tools.sh`; new 3rd run with `INSTALL_ZELLIJ=1` in `entrypoint.sh`
- Summary output shows `Zellij: ...` (or `未インストール (opt-in)`) on both OSes

Explicitly NOT in scope (deferred to PR2): tmux, `.tmux.conf`, README §6.3.2 / §7 tmux notes.

## Test plan

- [x] `bash -n` on all modified shell scripts
- [x] `shellcheck` clean on `install-multiplexer.sh`, `setup-local-linux.sh`, `setup-local-macos.sh`, `assert-tools.sh`, `entrypoint.sh`
- [x] `shfmt -d -i 2 -ci` clean
- [x] `markdownlint-cli2` clean on `README.md` / `README.ja.md`
- [x] `tests/smoke/run.sh` passes (14/14)
- [x] Pre-commit hooks (lefthook) pass: markdownlint / gitleaks / agentic-bootstrap-shell / trivy
- [x] commitlint passes (Conventional Commits)
- [x] `mise install zellij@0.44.3` succeeds locally (aqua backend)
- [ ] Integration test (Docker) green on Ubuntu 22.04 / 24.04 — verified by CI
- [ ] Manual run with `INSTALL_ZELLIJ=1` → `zellij --version` works

Closes #148 PR1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)