### PR TITLE
chore(commons): pin .gemini/settings.json (skills sync owns it)

### DIFF
--- a/.commons/sync.yaml
+++ b/.commons/sync.yaml
@@ -16,6 +16,7 @@ pinned:
   - .devcontainer/Dockerfile
   - .devcontainer/devcontainer.json
   - .devcontainer/initialize.sh
+  - .gemini/settings.json
   - .github/workflows/pr-check.yaml
   - .github/workflows/sync-commons.yaml
   - .gitignore

--- a/.gemini/settings.json
+++ b/.gemini/settings.json
@@ -1,7 +1,1 @@
-{
-  "context": {
-    "fileName": [
-      "AGENTS.md"
-    ]
-  }
-}
+{ "context": { "fileName": ["AGENTS.md"] } }


### PR DESCRIPTION
## Summary

\`.gemini/settings.json\` is being rewritten in opposite directions by two sync workflows, producing an infinite reciprocal-PR churn:

| 時刻 (UTC) | PR | 操作 | 駆動元 |
|---|---|---|---|
| 18:06:47 | #145 (merged) | 1 行 → 整形 multi-line | commons sync |
| 18:06:58 | #151 (open) | 整形 → 1 行 | skills sync |

Without intervention, every weekly schedule round trips this file with no net change.

## Fix

1. **Add \`.gemini/settings.json\` to \`.commons/sync.yaml\` pinned list** so commons sync stops touching it.
2. **Reformat \`.gemini/settings.json\` to single-line** (skills canonical form) so the next skills sync run does not immediately re-create the equivalent of #151.

Skills becomes the sole master of this file — justified because \`.gemini/settings.json\` is explicitly listed as an adapter source in the skills repo (\`dist/gemini-cli/.gemini/settings.json\`).

## After this PR merges

- #151 will be closed as redundant (its only change is the same single-line revert this PR includes)
- Future commons sync runs ignore \`.gemini/settings.json\`
- Future skills sync runs leave the file alone since main already matches the skills canonical form

## Test plan

- [x] lefthook hooks pass locally (gitleaks / yaml / trivy / commitlint)
- [x] diff is minimal: 1 line added to sync.yaml pinned + 6 lines removed from settings.json
- [ ] CI green