### PR TITLE
fix(dotfiles): include trivy in mise global config

### DIFF
--- a/dotfiles/dot_config/mise/config.toml
+++ b/dotfiles/dot_config/mise/config.toml
@@ -21,6 +21,11 @@ python = "latest"
 # 移行 (0.11.0+) に追従していないため、github バックエンドに切替えて回避する。
 # https://github.com/aquaproj/aqua-registry/blob/main/pkgs/astral-sh/uv/registry.yaml
 "github:astral-sh/uv" = "0.11.9"
+# trivy も aqua レジストリの signer_workflow が aquasecurity/trivy の Immutable
+# Release 移行に追従していないため、github バックエンドに切替えて回避する。
+# lefthook の pre-commit フックが `mise exec -- trivy ...` を呼ぶため、
+# chezmoi apply 後も global config に残るよう必ずここで明示する。
+"github:aquasecurity/trivy" = "0.70.0"
 gitleaks = "8.30.1"
 ast-grep = "0.42.1"
 yq = "4.53.2"


### PR DESCRIPTION
## Summary

- `dotfiles/dot_config/mise/config.toml` に `"github:aquasecurity/trivy" = "0.70.0"` を追加し、`./install.sh local` 末尾の `chezmoi apply` がユーザの global mise config を上書きした後でも trivy がグローバルに残るようにする。
- これにより、`lefthook` の `agentic-bootstrap-trivy` pre-commit フック（`mise exec -- trivy fs ...`）が install 直後の初回 commit から動作する。

## 背景

`config.toml` のヘッダコメントの注意書きどおり、このテンプレートに無いツールは `chezmoi apply` 後に global config から消える。trivy は `install_*` スクリプトでは `mise use --global` されないが、`lefthook.yaml` / `lefthook-base.yaml` の hook が `mise exec -- trivy` を呼ぶため、エントリ不在のままだと:

```
mise ERROR "trivy" couldn't exec process: No such file or directory
```

で hook が必ず失敗していた。

## バックエンドとバージョン選定

- backend: `github:aquasecurity/trivy`（aqua レジストリの signer_workflow が aquasecurity/trivy の Immutable Release 移行に追従しない既知問題を回避。memory `aqua-registry の追従ずれパターン` 準拠）
- version: `0.70.0`（`aquasecurity/trivy` の現行 latest stable をピン。以後の更新は Renovate の mise manager が自動 PR 化）

## 検証

- `mise install 'github:aquasecurity/trivy@0.70.0'` → 成功
- `mise exec 'github:aquasecurity/trivy@0.70.0' -- trivy --version` → `Version: 0.70.0`
- `chezmoi diff --source dotfiles` で `~/.config/mise/config.toml` に当該行が追加されることを確認
- pre-commit hook (`agentic-bootstrap-trivy`) で本 PR 自身のコミットが通過することを確認

## スコープ外（既知）

- `lefthook-base.yaml` は commons 由来のため本 PR では変更しない。
- `--scanners vuln,secret` vs `--scanners vuln` の挙動差は issue 本文どおり別件。

Closes #144