### PR TITLE
test(integration): add upgrade-from-prior-version scenario matrix

### DIFF
--- a/.github/workflows/test-integration.yaml
+++ b/.github/workflows/test-integration.yaml
@@ -21,13 +21,18 @@ jobs:
       github.event_name == 'push' ||
       github.event_name == 'workflow_dispatch' ||
       contains(github.event.pull_request.labels.*.name, 'ci:integration')
-    name: Integration test (ubuntu:${{ matrix.ubuntu }})
+    name: Integration test (ubuntu:${{ matrix.ubuntu }}, ${{ matrix.scenario }})
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
         ubuntu: ["22.04", "24.04"]
+        # fresh: クリーンな ubuntu イメージから install.sh を実行（既存）
+        # upgrade: 直近リリース tag の install.sh で bootstrap 済みの
+        #          イメージに HEAD コードを重ねて再実行し、過去版が残した
+        #          state を新コードが正しく扱えるかを検証（issue #142）
+        scenario: [fresh, upgrade]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -44,21 +49,25 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
 
-      - name: Build test image (ubuntu:${{ matrix.ubuntu }})
+      - name: Build test image (ubuntu:${{ matrix.ubuntu }}, ${{ matrix.scenario }})
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: .
-          file: tests/integration/Dockerfile
+          file: tests/integration/Dockerfile${{ matrix.scenario == 'upgrade' && '.upgrade' || '' }}
           build-args: |
             UBUNTU_VERSION=${{ matrix.ubuntu }}
-          tags: agentic-bootstrap-test:${{ matrix.ubuntu }}
+          tags: agentic-bootstrap-test:${{ matrix.ubuntu }}-${{ matrix.scenario }}
           load: true
-          cache-from: type=gha,scope=ubuntu-${{ matrix.ubuntu }}
-          cache-to: type=gha,scope=ubuntu-${{ matrix.ubuntu }},mode=max
+          # cache scope を scenario ごとに分離する。fresh と upgrade は
+          # 別 Dockerfile かつ多段ビルド構成も異なるため、共有すると
+          # cache hit 率が下がる。
+          cache-from: type=gha,scope=ubuntu-${{ matrix.ubuntu }}-${{ matrix.scenario }}
+          cache-to: type=gha,scope=ubuntu-${{ matrix.ubuntu }}-${{ matrix.scenario }},mode=max
 
       - name: Run integration test (install + idempotency)
         env:
           # mise の GitHub API 叩きを認証して rate limit を 5000/hr に上げる
           GITHUB_TOKEN_FOR_MISE: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          docker run --rm -e "GITHUB_TOKEN=$GITHUB_TOKEN_FOR_MISE" agentic-bootstrap-test:${{ matrix.ubuntu }}
+          docker run --rm -e "GITHUB_TOKEN=$GITHUB_TOKEN_FOR_MISE" \
+            agentic-bootstrap-test:${{ matrix.ubuntu }}-${{ matrix.scenario }}

--- a/tests/integration/Dockerfile.upgrade
+++ b/tests/integration/Dockerfile.upgrade
@@ -1,0 +1,94 @@
+# =======================================================================
+# tests/integration/Dockerfile.upgrade
+# -----------------------------------------------------------------------
+# 「過去リリースの install.sh が残した state を、現バージョン (HEAD) が
+# 正しくハンドリングできるか」を検証する upgrade-path 統合テスト。
+#
+# 既存 Dockerfile はクリーンな ubuntu イメージから始めるため、実 user が
+# 踏む「前バージョン → 現バージョン」経路が一度も走らない。
+# Bug 例（PR #140 で修正）:
+#   - 旧 add-apt-repository が書いた deb822 .sources を、新コードの
+#     .list グロブ存在チェックが見逃す（Conflicting Signed-By 競合）
+#   - 旧 mise の trusted-config 未登録状態で shim 呼び出しがエラー
+# どちらも 1st run from-scratch では再現しない。upgrade scenario で
+# のみ表面化する。
+#
+# 多段ビルド構成:
+#   Stage 1: ubuntu:${UBUNTU_VERSION} + 前提パッケージ + 過去 tag の
+#            install.sh を実行（PRIOR_TAG リリースの完成状態を再現）
+#   Stage 2: Stage 1 をベースに /workspace に HEAD コードを上書きコピー、
+#            entrypoint.sh で HEAD の install.sh local を再実行する
+#
+# PRIOR_TAG の更新方針:
+#   直近の安定リリースを 1 つだけピンする（多 tag matrix はコスト過大）。
+#   新リリースが切られたら本 ARG を手で bump、または Renovate のような
+#   仕組みで追従する。
+# =======================================================================
+
+ARG UBUNTU_VERSION=24.04
+ARG PRIOR_TAG=v0.2.0
+
+# -----------------------------------------------------------------------
+# Stage 1: 過去 tag の install.sh で bootstrap 済み状態を作る
+# -----------------------------------------------------------------------
+FROM ubuntu:${UBUNTU_VERSION} AS prior
+
+# 既存 Dockerfile と同等の env と前提パッケージ
+ENV DEBIAN_FRONTEND=noninteractive \
+    TZ=Asia/Tokyo \
+    LANG=C.UTF-8 \
+    CI=true \
+    AGENTIC_BOOTSTRAP_ASSUME_YES=1 \
+    INSTALL_CONTAINER=0
+
+# 過去 tag の install.sh が依存する最小前提を満たす。
+# 既存 Dockerfile と同じ集合（後段で重複インストールしても apt-get は冪等）。
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        sudo \
+        git \
+        gnupg \
+        locales \
+        tzdata \
+        software-properties-common \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN useradd --create-home --shell /bin/bash testuser \
+    && echo 'testuser ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/testuser \
+    && chmod 0440 /etc/sudoers.d/testuser
+
+USER testuser
+WORKDIR /home/testuser
+
+# Git の最低限の設定（プロンプト回避）
+RUN git config --global user.name "Test User" \
+    && git config --global user.email "test@example.com"
+
+# 過去 tag の install.sh を curl|bash 経由で実行する。
+# 本物のユーザが実行する経路（README の "curl ... | bash -s -- local"）を
+# 完全に踏ませることで、tarball 展開先 / state 配置を実環境と一致させる。
+# 過去版がインタラクティブな prompt を持っていても CI=true と
+# AGENTIC_BOOTSTRAP_ASSUME_YES=1 で非対話化される。
+ARG PRIOR_TAG
+RUN set -eux; \
+    curl -fsSL "https://raw.githubusercontent.com/ozzy-labs/agentic-bootstrap/${PRIOR_TAG}/install.sh" \
+      | bash -s -- local
+
+# -----------------------------------------------------------------------
+# Stage 2: HEAD コードを上書きして再 install
+# -----------------------------------------------------------------------
+FROM prior AS upgrade
+
+USER root
+WORKDIR /workspace
+COPY --chown=testuser:testuser . /workspace
+
+USER testuser
+
+# 既存 Dockerfile と同じ entrypoint を共有する。entrypoint.sh が
+# /workspace/install.sh local を 2 回実行し、assert_no_fatal_errors と
+# assert-tools.sh で検証する。1st run が「アップグレード後の初回」、
+# 2nd run が「アップグレード後の冪等性」を担当する。
+ENTRYPOINT ["/workspace/tests/integration/entrypoint.sh"]

--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -5,15 +5,35 @@
 # ローカルで Docker 統合テストを走らせるハーネス。
 #
 # Usage:
-#   ./tests/integration/run.sh                 # デフォルト (24.04)
+#   ./tests/integration/run.sh                 # デフォルト (24.04, fresh)
 #   ./tests/integration/run.sh 22.04           # 単一バージョン
 #   ./tests/integration/run.sh 22.04 24.04     # 複数バージョン逐次
 #   ./tests/integration/run.sh devel           # Canary（次期 Linux リリース）
+#
+# Environment variables:
+#   SCENARIO=fresh|upgrade   # 既定 fresh。upgrade は直近リリース tag で
+#                            # bootstrap 後に HEAD コードで再 install し、
+#                            # 過去版 state のマイグレーション経路を検証
+#                            # （Dockerfile.upgrade を使う）
 # =======================================================================
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+SCENARIO="${SCENARIO:-fresh}"
+case "$SCENARIO" in
+fresh)
+  DOCKERFILE="$SCRIPT_DIR/Dockerfile"
+  ;;
+upgrade)
+  DOCKERFILE="$SCRIPT_DIR/Dockerfile.upgrade"
+  ;;
+*)
+  echo "❌ Unknown SCENARIO='$SCENARIO' (expected: fresh|upgrade)"
+  exit 1
+  ;;
+esac
 
 if ! command -v docker >/dev/null 2>&1; then
   echo "⚠️  docker コマンドが見つかりません"
@@ -46,28 +66,28 @@ FAILED_VERSIONS=()
 
 for version in "${VERSIONS[@]}"; do
   printf '\n═══════════════════════════════════════════\n'
-  printf '🐳 Testing against ubuntu:%s\n' "$version"
+  printf '🐳 Testing against ubuntu:%s (scenario: %s)\n' "$version" "$SCENARIO"
   printf '═══════════════════════════════════════════\n'
 
-  tag="agentic-bootstrap-test:${version//[^A-Za-z0-9._-]/-}"
+  tag="agentic-bootstrap-test:${version//[^A-Za-z0-9._-]/-}-${SCENARIO}"
 
   if ! docker build \
     --build-arg "UBUNTU_VERSION=${version}" \
     -t "$tag" \
-    -f "$SCRIPT_DIR/Dockerfile" \
+    -f "$DOCKERFILE" \
     "$REPO_ROOT"; then
-    echo "❌ docker build failed for ubuntu:${version}"
+    echo "❌ docker build failed for ubuntu:${version} (scenario: ${SCENARIO})"
     FAILED_VERSIONS+=("$version")
     continue
   fi
 
   if ! docker run --rm "${DOCKER_ENV_ARGS[@]}" "$tag"; then
-    echo "❌ docker run failed for ubuntu:${version}"
+    echo "❌ docker run failed for ubuntu:${version} (scenario: ${SCENARIO})"
     FAILED_VERSIONS+=("$version")
     continue
   fi
 
-  printf '\n✅ ubuntu:%s passed\n' "$version"
+  printf '\n✅ ubuntu:%s passed (scenario: %s)\n' "$version" "$SCENARIO"
 done
 
 printf '\n═══════════════════════════════════════════\n'


### PR DESCRIPTION
## Summary

Add an `upgrade` scenario to the integration test matrix that exercises the "prior released version of `install.sh` left state → HEAD's `install.sh` runs over it" path. Existing fresh-image tests never run this, so the structural class of bug PR #140 fixed (legacy `*.sources` PPA files missed by `*.list` globs; untrusted `.mise.toml` from older mise) can ship undetected.

### Changes

- `tests/integration/Dockerfile.upgrade` (new, multi-stage):
  - Stage 1 (`prior`): clean `ubuntu:${UBUNTU_VERSION}` + minimal prereqs (same set as existing `Dockerfile`), then `curl ... v0.2.0/install.sh | bash -s -- local` non-interactively (`CI=true` + `AGENTIC_BOOTSTRAP_ASSUME_YES=1`).
  - Stage 2 (`upgrade`): COPY HEAD code into `/workspace`, re-uses existing `entrypoint.sh` so the same `assert_no_fatal_errors` + `assert-tools.sh` assertions catch silent failures.
- `.github/workflows/test-integration.yaml`: add `scenario: [fresh, upgrade]` matrix axis with per-scenario cache scope (`ubuntu-<ver>-<scenario>`) and per-scenario image tag.
- `tests/integration/run.sh`: support `SCENARIO=upgrade` for local reproduction.

### Design decisions

- **Single prior tag** pinned via `ARG PRIOR_TAG=v0.2.0`. Multi-tag matrix would blow up CI time for marginal coverage gain (issue's explicit "1 tag vs many" tradeoff). Bump the ARG when a new release ships major state-handling changes.
- **Reuse existing `entrypoint.sh`**: keeps the test surface unified — same fatal-keyword regex, same idempotency / pipe-mode / opt-in-multiplexer subtests run after upgrade.
- **No changes to `canary.yaml`** (out-of-scope per issue's prior-decision pattern).

### Verify locally

```bash
docker build -f tests/integration/Dockerfile.upgrade --build-arg UBUNTU_VERSION=24.04 -t agentic-bootstrap-upgrade .
SCENARIO=upgrade ./tests/integration/run.sh 24.04
```

Both 22.04 and 24.04 builds verified locally with `docker build --check` (no warnings) and full end-to-end run on 24.04 (Stage 1 v0.2.0 install completes, Stage 2 HEAD install + idempotency + pipe-mode subtests all pass). The only assertion failure observed (`zellij --version` in 3rd run) is a pre-existing issue on `main` — same failure shows on `fresh` matrix in [run #26691506719](https://github.com/ozzy-labs/agentic-bootstrap/actions/runs/26691506719) and is independent of this PR.

### Test plan

- [x] `shfmt -d` / `shellcheck --severity=warning` clean on `tests/integration/run.sh`
- [x] `yamlfmt` / `yamllint` / `actionlint` clean on `.github/workflows/test-integration.yaml`
- [x] `docker build --check` clean on `Dockerfile.upgrade` for both `UBUNTU_VERSION=22.04` and `24.04`
- [x] Local end-to-end run on ubuntu:24.04 — Stage 1 (v0.2.0 install) completes, Stage 2 (HEAD install) reaches 3rd run and only fails on the pre-existing zellij assertion (also fails on `fresh`, not caused by this PR)
- [ ] CI: `ci:integration` label applied to surface both `fresh` and `upgrade` matrix axes

Closes #142