### PR TITLE
fix(dotfiles): include zellij in mise global config

### DIFF
--- a/dotfiles/dot_config/mise/config.toml
+++ b/dotfiles/dot_config/mise/config.toml
@@ -33,3 +33,8 @@ chezmoi = "2.70.2"
 just = "1.50.0"
 zoxide = "0.9.9"
 shellcheck = "0.11.0"
+# zellij は opt-in multiplexer (scripts/lib/install-multiplexer.sh が
+# INSTALL_ZELLIJ=1 のときに mise use --global で導入) だが、chezmoi apply 後も
+# global config に残るよう必ずここで明示する (#149 で導入、#155 で修正)。
+# aqua バックエンドで動作確認済み。
+zellij = "0.44.3"


### PR DESCRIPTION
## Summary

Closes #155.

`zellij` was being installed via `mise use --global zellij@0.44.3` in `install_multiplexer_tools` but then immediately wiped from `~/.config/mise/config.toml` by the `chezmoi apply` in `install_dev_tools` (the dotfiles template at `dotfiles/dot_config/mise/config.toml` lacked a zellij entry).

Same class of bug as #144 (trivy). Integration test on main has been failing 4 consecutive runs as a result.

## Fix

Add `zellij = "0.44.3"` to the dotfiles template, matching the pin in `scripts/lib/install-multiplexer.sh` and `scripts/setup-local-macos.sh`. aqua backend works (verified in install logs of the failing CI run). Renovate mise manager will auto-PR future bumps.

## Test plan

- [x] lefthook hooks pass locally (taplo / trivy / gitleaks / commitlint)
- [x] No other mise-managed tools missing from template (audited node/pnpm/python/uv/gitleaks/ast-grep/yq/chezmoi/just/zoxide/shellcheck/trivy — all present; zellij was the only gap)
- [ ] CI integration test goes green (3rd run INSTALL_TMUX=1 INSTALL_ZELLIJ=1 → `zellij --version` should now succeed post-chezmoi-apply)

## Reference

- Failing CI run before this fix: [run 26691506719](https://github.com/ozzy-labs/agentic-bootstrap/actions/runs/26691506719)