### PR TITLE
fix(prompts): fail-loud when /dev/tty attach fails (silent prompt-invisibility bug)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -776,6 +776,41 @@ INSTALL_TMUX=1 ./install.sh local
 - prefix キーはデフォルト（C-b）維持、vi/emacs mode-keys / プラグインマネージャは入れない
 ```
 
+**7.1.7 `curl ... | bash` で対話プロンプトが表示されない場合**
+
+一部の環境（特定の WSL2 構成、controlling terminal を持たないコンテナ、ネストした subshell など）では、`curl ... | bash` で起動した bash サブシェルから `/dev/tty` が open できないことがある。この場合、対話プロンプトを表示できないため、隠れたプロンプトに既定値で勝手に進むのではなく、明示的なエラーで中断するようになっている。
+
+```bash
+# エラーメッセージ例
+⚠️  対話プロンプト用の TTY を確保できませんでした
+ℹ️  考えられる原因:
+    - stdin が pipe で、/dev/tty へのフォールバックも失敗した
+    - curl ... | bash 実行時に /dev/tty が利用不可（WSL2 の一部環境 / コンテナ / サブシェル）
+ℹ️  対処法:
+    1. ファイル経由で実行する（推奨）: ...
+    2. プロセス置換で実行する: ...
+    3. 非対話モードで実行する: ...
+```
+
+以下のいずれかの対処法を選ぶ:
+
+```bash
+# (a) ファイル経由実行（最も確実。事前にスクリプトを目視レビューも可能）
+curl --proto '=https' --tlsv1.2 -fsSL \
+  https://raw.githubusercontent.com/ozzy-labs/agentic-bootstrap/main/install.sh \
+  -o /tmp/install.sh
+bash /tmp/install.sh local
+
+# (b) プロセス置換（ワンライナーの形を保ちつつ、stdin に実 TTY が戻る）
+bash <(curl --proto '=https' --tlsv1.2 -fsSL \
+  https://raw.githubusercontent.com/ozzy-labs/agentic-bootstrap/main/install.sh) local
+
+# (c) 非対話モード（既定値で全カテゴリをインストール）
+curl --proto '=https' --tlsv1.2 -fsSL \
+  https://raw.githubusercontent.com/ozzy-labs/agentic-bootstrap/main/install.sh \
+  | AGENTIC_BOOTSTRAP_ASSUME_YES=1 bash -s -- local
+```
+
 ### 7.2 ログの確認方法
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -776,6 +776,41 @@ INSTALL_TMUX=1 ./install.sh local
 - Default prefix (C-b) kept; no vi/emacs mode-keys; no plugin manager
 ```
 
+**7.1.7 `curl ... | bash` aborts with "TTY を確保できませんでした"**
+
+Some environments (notably certain WSL2 configurations, containers without a controlling terminal, or nested subshells) cannot reach `/dev/tty` from the bash subshell spawned by `curl ... | bash`. In these cases, the install script can no longer show interactive prompts, so it now aborts with a clear error rather than silently proceeding with default values for hidden prompts.
+
+```bash
+# Error message example
+⚠️  対話プロンプト用の TTY を確保できませんでした
+ℹ️  考えられる原因:
+    - stdin が pipe で、/dev/tty へのフォールバックも失敗した
+    - curl ... | bash 実行時に /dev/tty が利用不可（WSL2 の一部環境 / コンテナ / サブシェル）
+ℹ️  対処法:
+    1. ファイル経由で実行する（推奨）: ...
+    2. プロセス置換で実行する: ...
+    3. 非対話モードで実行する: ...
+```
+
+Pick one of the following workarounds:
+
+```bash
+# (a) File-based execution — most reliable, also lets you inspect the script first
+curl --proto '=https' --tlsv1.2 -fsSL \
+  https://raw.githubusercontent.com/ozzy-labs/agentic-bootstrap/main/install.sh \
+  -o /tmp/install.sh
+bash /tmp/install.sh local
+
+# (b) Process substitution — keeps the one-liner shape while restoring a real TTY for stdin
+bash <(curl --proto '=https' --tlsv1.2 -fsSL \
+  https://raw.githubusercontent.com/ozzy-labs/agentic-bootstrap/main/install.sh) local
+
+# (c) Non-interactive mode — accept all defaults (install every category)
+curl --proto '=https' --tlsv1.2 -fsSL \
+  https://raw.githubusercontent.com/ozzy-labs/agentic-bootstrap/main/install.sh \
+  | AGENTIC_BOOTSTRAP_ASSUME_YES=1 bash -s -- local
+```
+
 ### 7.2 Checking Logs
 
 ```bash

--- a/scripts/lib/prompts.sh
+++ b/scripts/lib/prompts.sh
@@ -38,11 +38,44 @@ _prompt_default_no() {
 # 非対話モード（CI / ASSUME_YES）ではフォールバックしない。
 # 呼び出し側スクリプト先頭で `_attach_tty_if_needed` を呼ぶ。
 #
-# /dev/tty が device file として存在するが open に失敗するケース（一部の
-# コンテナ / サブシェル）でもスクリプト全体を落とさないよう、exec の失敗を
-# 黙って受け流す。
+# /dev/tty へのフォールバックが必要なのに失敗した場合（curl|bash + WSL2 等で
+# /dev/tty が `No such device or address` になるケース）は、プロンプトが
+# 表示されないまま read だけが進行する致命的 UX 不具合を避けるため、明示的
+# なエラーメッセージを出して exit 1 する。silent fallback はしない。
 _attach_tty_if_needed() {
-  if [ ! -t 0 ] && [ -r /dev/tty ] && ! _is_non_interactive; then
-    exec </dev/tty 2>/dev/null || true
+  # 既に TTY を持っている / 非対話モード → 何もしない
+  if [ -t 0 ] || _is_non_interactive; then
+    return 0
   fi
+
+  # /dev/tty への attach を試行
+  # 注意: `exec </dev/tty 2>/dev/null` の 2>/dev/null は exec 自身の
+  # redirection failure メッセージを抑止しない（bash の仕様）。
+  # `{ exec ...; } 2>/dev/null` のグルーピング経由で抑止する必要がある。
+  # グループ内の exec は親シェルの stdin を引き継ぐ（subshell ではないため）。
+  if [ -c /dev/tty ] && { exec </dev/tty; } 2>/dev/null; then
+    return 0
+  fi
+
+  # ここに来た時点で stdin は非 TTY、/dev/tty も open 不能。
+  # 黙って続行すると read -p のプロンプトが一切表示されなくなるので fail-loud する。
+  {
+    printf '%s\n' "⚠️  対話プロンプト用の TTY を確保できませんでした"
+    printf '%s\n' "ℹ️  考えられる原因:"
+    printf '%s\n' "    - stdin が pipe で、/dev/tty へのフォールバックも失敗した"
+    printf '%s\n' "    - curl ... | bash 実行時に /dev/tty が利用不可（WSL2 の一部環境 / コンテナ / サブシェル）"
+    printf '%s\n' "ℹ️  対処法:"
+    printf '%s\n' "    1. ファイル経由で実行する（推奨）:"
+    printf '%s\n' "         curl --proto '=https' --tlsv1.2 -fsSL \\"
+    printf '%s\n' "           https://raw.githubusercontent.com/ozzy-labs/agentic-bootstrap/main/install.sh \\"
+    printf '%s\n' "           -o /tmp/install.sh && bash /tmp/install.sh local"
+    printf '%s\n' "    2. プロセス置換で実行する:"
+    printf '%s\n' "         bash <(curl --proto '=https' --tlsv1.2 -fsSL \\"
+    printf '%s\n' "           https://raw.githubusercontent.com/ozzy-labs/agentic-bootstrap/main/install.sh) local"
+    printf '%s\n' "    3. 非対話モードで実行する（全カテゴリを既定値でインストール）:"
+    printf '%s\n' "         curl --proto '=https' --tlsv1.2 -fsSL \\"
+    printf '%s\n' "           https://raw.githubusercontent.com/ozzy-labs/agentic-bootstrap/main/install.sh \\"
+    printf '%s\n' "           | AGENTIC_BOOTSTRAP_ASSUME_YES=1 bash -s -- local"
+  } >&2
+  exit 1
 }

--- a/tests/unit/prompts.bats
+++ b/tests/unit/prompts.bats
@@ -77,3 +77,89 @@ setup() {
   _prompt_default_no "Continue? [y/N]: " >"$OUT_FILE"
   [ "$REPLY" = "N" ]
 }
+
+# ------------------------------------------------------------------
+# _attach_tty_if_needed
+#
+# stdin が TTY または非対話モードのときは何もしない。
+# stdin が非 TTY かつ /dev/tty が open 不能のときは fail-loud して exit 1 する。
+#
+# 注意: bats 自体が pipe で実行されるため、関数呼び出しは subshell に
+# 隔離する。fail-loud 経路は `bash -c '...' </dev/null` でテストする。
+# ------------------------------------------------------------------
+
+@test "_attach_tty_if_needed: returns 0 when stdin is already a TTY" {
+  # 関数を subshell で呼び、stdin を /dev/null にしないため
+  # bats の stdin (通常は TTY、CI では非 TTY) をそのまま使う。
+  # CI 上では下の non-interactive ケースと同等になるが、
+  # 少なくとも exit/error にはならないことを検証する。
+  CI=true
+  unset AGENTIC_BOOTSTRAP_ASSUME_YES BOOTSTRAP_ASSUME_YES
+  run _attach_tty_if_needed
+  [ "$status" -eq 0 ]
+}
+
+@test "_attach_tty_if_needed: returns 0 in non-interactive mode (CI=true)" {
+  # 別 bash 経由で stdin を pipe (closed) にし、CI=true を立てて
+  # 非対話モードの早期 return を確認する。
+  run bash -c '
+    set -e
+    cd "'"$SCRIPT_ROOT"'"
+    # shellcheck disable=SC1091
+    . scripts/lib/detect.sh
+    # shellcheck disable=SC1091
+    . scripts/lib/prompts.sh
+    unset AGENTIC_BOOTSTRAP_ASSUME_YES BOOTSTRAP_ASSUME_YES
+    CI=true _attach_tty_if_needed
+    echo "ok"
+  ' </dev/null
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"ok"* ]]
+}
+
+@test "_attach_tty_if_needed: returns 0 with AGENTIC_BOOTSTRAP_ASSUME_YES=1" {
+  run bash -c '
+    set -e
+    cd "'"$SCRIPT_ROOT"'"
+    # shellcheck disable=SC1091
+    . scripts/lib/detect.sh
+    # shellcheck disable=SC1091
+    . scripts/lib/prompts.sh
+    unset CI BOOTSTRAP_ASSUME_YES
+    AGENTIC_BOOTSTRAP_ASSUME_YES=1 _attach_tty_if_needed
+    echo "ok"
+  ' </dev/null
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"ok"* ]]
+}
+
+@test "_attach_tty_if_needed: exits 1 with helpful message when stdin is pipe and /dev/tty unreachable" {
+  # bash -c '...' </dev/null は controlling terminal を持たない subshell を作る。
+  # この状態で /dev/tty を open すると "No such device or address" になり、
+  # fail-loud 経路を踏む。
+  #
+  # この環境的前提が成り立たないホスト (controlling terminal が引き継がれる bats runner) では
+  # skip する。
+  if bash -c '{ exec </dev/tty; } 2>/dev/null' </dev/null; then
+    skip "controlling terminal is reachable from subshell; cannot reproduce fail-loud scenario"
+  fi
+  run bash -c '
+    cd "'"$SCRIPT_ROOT"'"
+    # shellcheck disable=SC1091
+    . scripts/lib/detect.sh
+    # shellcheck disable=SC1091
+    . scripts/lib/prompts.sh
+    unset CI AGENTIC_BOOTSTRAP_ASSUME_YES BOOTSTRAP_ASSUME_YES
+    _attach_tty_if_needed
+    echo "should not reach"
+  ' </dev/null 2>&1
+  [ "$status" -eq 1 ]
+  [[ "$output" != *"should not reach"* ]]
+  [[ "$output" == *"対話プロンプト用の TTY を確保できませんでした"* ]]
+  [[ "$output" == *"考えられる原因"* ]]
+  [[ "$output" == *"対処法"* ]]
+  # 3 つの workaround すべてが含まれることを確認
+  [[ "$output" == *"ファイル経由"* ]]
+  [[ "$output" == *"プロセス置換"* ]]
+  [[ "$output" == *"AGENTIC_BOOTSTRAP_ASSUME_YES=1"* ]]
+}


### PR DESCRIPTION
Closes #158

## Summary

When `curl ... | bash -s -- local` runs in environments where `/dev/tty` is unreachable from the bash subshell (notably some WSL2 setups, containers without a controlling terminal, nested subshells), the install script's interactive prompts become **completely invisible** and the script silently proceeds while consuming user keystrokes one byte at a time.

This PR replaces the silent `|| true` fallback in `_attach_tty_if_needed` with an explicit fail-loud error that includes 3 actionable workarounds.

## Root cause

1. `read -p prompt` only displays the prompt when stdin is a terminal (documented bash behavior)
2. `_attach_tty_if_needed` tried `exec </dev/tty 2>/dev/null || true` to upgrade stdin pipe → terminal
3. When `/dev/tty` was unreachable (`No such device or address`), `|| true` silently swallowed the failure
4. stdin stayed as the closed pipe — all subsequent `read -p` calls produced no visible prompt
5. User saw only the static `echo` headers (e.g. `🪟 Terminal multiplexer:`) with nothing in between

### Reproducing (before fix)

```bash
echo "n" | bash -c '
  . scripts/lib/detect.sh
  . scripts/lib/prompts.sh
  _attach_tty_if_needed
  read -p "選択 [Y/n]: " -n 1 -r VAR || true
  echo ""
  echo "user input: [$VAR]"
  read -p "📌 prompt 2: " -n 1 -r REPLY || true
  echo ""
  echo "REPLY: [$REPLY]"
' 2>&1
```

Before: the bash redirection error leaked, both `read -p` calls ran with no visible prompt, second `REPLY` ended up empty.

After: the script aborts with a clear error listing 3 workarounds; the user is never left guessing why prompts are invisible.

## Changes

- `scripts/lib/prompts.sh` — `_attach_tty_if_needed` now has three explicit branches:
  - Already TTY or non-interactive → `return 0`
  - `/dev/tty` open succeeds → `return 0`
  - Otherwise → print actionable error (3 workarounds) and `exit 1`
- Also fixes a subtle bash quirk: plain `exec </dev/tty 2>/dev/null` does **not** suppress the redirection failure message (stderr redirect runs as part of exec itself). Uses `{ exec </dev/tty; } 2>/dev/null` group form, which suppresses the message while still persisting the fd into the parent shell.
- `tests/unit/prompts.bats` — adds 4 new tests covering all three branches, with a runtime-skip for hosts where subshells inherit a controlling terminal (cannot reproduce fail-loud scenario)
- `README.md` / `README.ja.md` §7.1.7 — documents the new error and the three workarounds

## Workarounds shown in the error message

```bash
# (a) File-based execution (most reliable)
curl ... -o /tmp/install.sh && bash /tmp/install.sh local

# (b) Process substitution (keeps one-liner shape)
bash <(curl ...) local

# (c) Non-interactive mode (accept all defaults)
curl ... | AGENTIC_BOOTSTRAP_ASSUME_YES=1 bash -s -- local
```

## Test plan

- [x] `bats tests/unit/prompts.bats` — 10/10 pass (6 existing + 4 new)
- [x] `bats tests/unit/` — 61/61 pass
- [x] `bash tests/smoke/run.sh` — 15/15 pass
- [x] `mise exec -- shfmt -d scripts/lib/prompts.sh` — clean
- [x] `mise exec -- shellcheck --severity=warning scripts/lib/prompts.sh` — clean
- [x] `mise exec -- markdownlint-cli2 README.md README.ja.md` — 0 errors
- [x] `lefthook run pre-commit` — all hooks pass
- [x] Manual reproduction of original `curl|bash + WSL2` symptom now aborts with clear error instead of consuming reads silently
- [ ] `ci:integration` label triggers Docker matrix for additional confidence

## Scope boundaries (intentionally out of scope)

- Does **not** change `scripts/setup-local-{linux,macos}.sh` prompt flow logic
- Does **not** change the recommended Quick Start invocation in §4 — the fix makes the underlying error visible, which is sufficient. Switching the default to `bash <(curl ...)` is a separate UX decision
- Does **not** modify `_prompt_default_yes` / `_prompt_default_no` themselves — they're correct; the upstream `_attach_tty_if_needed` is what was broken