### PR TITLE
chore(docs): replace AGENTS.md template residue with accurate agentic-bootstrap stack

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,28 +11,35 @@
 
 ## プロジェクト概要
 
-`<project-name>`: <description>
+`agentic-bootstrap`: Bash 製の開発ホストプロビジョナ (Linux/WSL2/macOS)。AI エージェント駆動開発に必要なツール群を一発で導入する。
 
 ## Tech Stack
 
-- Runtime: Node.js (ESM)
-- Package manager: pnpm
-- Version management: mise (`.mise.toml`)
+- Language: Bash (POSIX-friendly, bash 3.2+ compat on macOS, 4+ on Linux)
+- Hooks: lefthook
+- Tests: bats (unit), shell (smoke), Docker (integration)
+- Lint: shellcheck, shfmt, markdownlint, yamllint, actionlint, gitleaks, trivy, commitlint
+- Version management: mise (`.mise.toml` で repo / `.config/mise/config.toml` で global)
 
 ## 主要コマンド
 
 ```bash
-pnpm install               # 依存関係インストール
-pnpm run dev               # 開発サーバー起動
-pnpm run build             # プロダクションビルド
+./install.sh local         # ローカルホストへのセットアップ
+./install.sh update        # 既存ツール一括更新
+./install.sh doctor        # 環境健全性チェック
+lefthook run pre-commit    # 全 lint + format チェック
+bats tests/unit            # unit テスト
+bash tests/smoke/run.sh    # smoke テスト
 ```
 
 ## 検証（必須）
 
 コード変更後、報告前に以下を通すこと:
 
-1. `pnpm run build` — ビルド成功
-2. `pnpm run typecheck` — 型チェック通過
+1. `lefthook run pre-commit` — 全 lint pass
+2. `bash tests/smoke/run.sh` — smoke green
+3. `bats tests/unit` — unit green
+4. （shell/yaml/Dockerfile を変更した場合）integration test も推奨: `bash tests/integration/run.sh`
 
 ## コーディング規約
 


### PR DESCRIPTION
## Summary

Audit finding **Patch β**: `AGENTS.md` (lines ~13-32) carried template residue from the initial scaffold, describing a Node.js / pnpm project. This repo is Bash + lefthook + bats, so the content was **actively misleading** for AI agents reading the file as their primary instruction source.

Replace the four affected sections with accurate, repo-specific content. The auto-generated `<!-- begin: @ozzylabs/skills -->...<!-- end -->` block, the `基本方針` / `コーディング規約` / `規約` sections, and the `Adapter Files` table are kept intact.

## Sections replaced

- **プロジェクト概要**: real description of agentic-bootstrap (Bash 製の開発ホストプロビジョナ for Linux/WSL2/macOS).
- **Tech Stack**: Bash (POSIX-friendly, 3.2+ on macOS / 4+ on Linux), lefthook, bats + shell + Docker tests, full lint stack (shellcheck, shfmt, markdownlint, yamllint, actionlint, gitleaks, trivy, commitlint), mise.
- **主要コマンド**: `./install.sh local|update|doctor`, `lefthook run pre-commit`, `bats tests/unit`, `bash tests/smoke/run.sh`.
- **検証（必須）**: lefthook pre-commit + smoke + unit (and integration when shell/yaml/Dockerfile touched).

## Cross-check

- `rg -n "pnpm|Node\.js|ESM" AGENTS.md` → no matches (verified).
- `rg -n "pnpm install" *.md docs/` → no matches (verified). README.md / README.ja.md / CLAUDE.md were checked separately and are out of scope (handled by parallel patches).

## Out of scope

- `CLAUDE.md` (root and `.claude/`) — agent-specific adapter; separate concern.
- `.agents/AGENTS.md` — not present / not the same file.
- The `@ozzylabs/skills` auto-generated block.
- `README.md` / `README.ja.md` — parallel audit patches.

## Test plan

- [x] `lefthook run pre-commit` — markdownlint / gitleaks / trivy pass.
- [x] commitlint pass on Conventional Commit `chore(docs): ...`.
- [x] grep cross-checks above return no residue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)