### PR TITLE
test: automate PR #150 manual cases (.tmux.conf respect, macOS skip) + smoke lib syntax loop + doctor exit code

### DIFF
--- a/tests/integration/entrypoint.sh
+++ b/tests/integration/entrypoint.sh
@@ -10,6 +10,7 @@ set -eo pipefail
 RUN1_LOG="/tmp/run1.log"
 RUN2_LOG="/tmp/run2.log"
 RUN3_LOG="/tmp/run3.log"
+RUN4_LOG="/tmp/run4.log"
 ASSERT_SCRIPT="/workspace/tests/integration/assert-tools.sh"
 
 printf '\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n'
@@ -173,6 +174,60 @@ if ! grep -q 'tmux-256color' "$HOME/.tmux.conf"; then
   exit 1
 fi
 echo "✅ ~/.tmux.conf created with bundled defaults"
+
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+# 🔵 4th run — existing ~/.tmux.conf is respected (NOT overwritten)
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+#
+# PR #150 の手動テスト項目 #2 を自動化（audit gap δ-1）。
+# install_multiplexer_tools の `if [ -f "$HOME/.tmux.conf" ]` 分岐
+# （scripts/lib/install-multiplexer.sh:41）が、既存ユーザー設定を尊重して
+# 上書きしないことを検証する。README §7.1.6 で明記されている挙動。
+#
+# 3rd run 完了時点で ~/.tmux.conf が既に存在しているため、ここで内容を
+# センチネル付きの最小ファイルに置き換えてから INSTALL_TMUX=1 を再実行し、
+# センチネル行が保持されていること = 上書きされていないことを確認する。
+printf '\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n'
+printf '🔵 4th run — existing ~/.tmux.conf respected (NOT overwritten)\n'
+printf '━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n'
+
+TMUX_SENTINEL="# SENTINEL: pre-existing user config (audit-δ regression)"
+cat >"$HOME/.tmux.conf" <<EOF
+$TMUX_SENTINEL
+# 既存ユーザー設定を模擬。install_multiplexer_tools はこのファイルを
+# 検出して上書きせず "⏭️  ~/.tmux.conf は既に存在（上書きしません）" を出力するはず。
+set -g status-bg colour234
+EOF
+
+if ! INSTALL_TMUX=1 /workspace/install.sh local 2>&1 | tee "$RUN4_LOG"; then
+  echo "❌ 4th run (INSTALL_TMUX=1 with pre-existing ~/.tmux.conf) failed"
+  exit 1
+fi
+assert_no_fatal_errors "$RUN4_LOG" "4th run"
+
+# センチネル行が保持されていること = 上書きされていない
+if ! grep -qF "$TMUX_SENTINEL" "$HOME/.tmux.conf"; then
+  echo "❌ ~/.tmux.conf が上書きされています（センチネル行が消失）"
+  echo "--- 現在の ~/.tmux.conf ---"
+  cat "$HOME/.tmux.conf"
+  exit 1
+fi
+
+# 同梱の最小構成（tmux-256color）が混入していないこと（=完全に尊重されている）
+if grep -q 'tmux-256color' "$HOME/.tmux.conf"; then
+  echo "❌ ~/.tmux.conf に同梱構成（tmux-256color 行）が混入しています"
+  echo "   = 既存ファイルが merge or 上書きされている可能性"
+  cat "$HOME/.tmux.conf"
+  exit 1
+fi
+
+# 「上書きしません」スキップログが 4th run のログに出ていること
+if ! grep -q '上書きしません' "$RUN4_LOG"; then
+  echo "❌ 4th run のログに「上書きしません」スキップメッセージがありません"
+  echo "   install_multiplexer_tools の既存ファイル分岐が走っていない可能性"
+  exit 1
+fi
+echo "✅ ~/.tmux.conf is respected (sentinel preserved, skip log emitted)"
 
 # NOTE: setup-local-linux.sh の直接 pipe 実行テストは、scripts/lib/*.sh への
 # 責務分割（#88）以降は実装と整合しないため削除した。実環境では

--- a/tests/smoke/run.sh
+++ b/tests/smoke/run.sh
@@ -146,6 +146,35 @@ assert_success "update-tools.sh syntax check" \
 assert_success "doctor.sh syntax check" \
   bash -n scripts/doctor.sh
 
+# scripts/lib/*.sh の構文チェック（audit gap δ-2）。
+# トップレベル 6 スクリプトしか syntax check していなかったため、lib 配下に
+# bash -n エラーが混入すると smoke を通過し integration まで検知が遅れていた。
+# ここで全 lib を網羅的にチェックする。
+for lib in scripts/lib/*.sh; do
+  assert_success "syntax check: $lib" bash -n "$lib"
+done
+
+# ------------------------------------------------------------------
+# 4. doctor.sh exit code 範囲チェック（audit gap δ-3）
+# ------------------------------------------------------------------
+#
+# doctor は 0 / 1 / 2 を返す仕様（README §6.5.2）。smoke では doctor の
+# 発火と exit code が想定範囲内かのみ確認する（深い内容検証は別レイヤ）。
+# fresh subagent worktree は warn が出やすいため 0 / 1 を許容する。
+# 2 (error)・3 以上は即 fail。
+printf '▶ doctor.sh exit code in {0,1}\n'
+set +e
+bash scripts/doctor.sh >/dev/null 2>&1
+doctor_exit=$?
+set -e
+if [ "$doctor_exit" -eq 0 ] || [ "$doctor_exit" -eq 1 ]; then
+  printf '  ✅ pass (exit=%d)\n' "$doctor_exit"
+  PASS=$((PASS + 1))
+else
+  printf '  ❌ fail (exit=%d, expected 0/1)\n' "$doctor_exit"
+  FAIL=$((FAIL + 1))
+fi
+
 # ------------------------------------------------------------------
 # サマリー
 # ------------------------------------------------------------------

--- a/tests/smoke/run.sh
+++ b/tests/smoke/run.sh
@@ -162,11 +162,13 @@ done
 # 発火と exit code が想定範囲内かのみ確認する（深い内容検証は別レイヤ）。
 # fresh subagent worktree は warn が出やすいため 0 / 1 を許容する。
 # 2 (error)・3 以上は即 fail。
+#
+# NOTE: 本スクリプトは `set -u` のみで `set -e` を使わない。`set +e/-e` 切替は
+# 副作用（後続コード全体に errexit を残す）が出るため、`|| true` で exit code を
+# 捕捉する pattern を使う。
 printf '▶ doctor.sh exit code in {0,1}\n'
-set +e
-bash scripts/doctor.sh >/dev/null 2>&1
-doctor_exit=$?
-set -e
+doctor_exit=0
+bash scripts/doctor.sh >/dev/null 2>&1 || doctor_exit=$?
 if [ "$doctor_exit" -eq 0 ] || [ "$doctor_exit" -eq 1 ]; then
   printf '  ✅ pass (exit=%d)\n' "$doctor_exit"
   PASS=$((PASS + 1))

--- a/tests/unit/install-multiplexer.bats
+++ b/tests/unit/install-multiplexer.bats
@@ -1,0 +1,183 @@
+#!/usr/bin/env bats
+# =======================================================================
+# tests/unit/install-multiplexer.bats
+# -----------------------------------------------------------------------
+# scripts/lib/install-multiplexer.sh の install_multiplexer_tools 関数を
+# 検証する。apt_install_or_upgrade / mise_use_global / ensure_mise_installed
+# をすべてモックして、外部依存（apt, mise, network）を一切呼ばない。
+#
+# 検証範囲（audit gap δ-1 part 2）:
+#   - INSTALL_TMUX=1 → apt 経路が呼ばれ、~/.tmux.conf が新規作成される
+#   - INSTALL_TMUX=1 + 既存 ~/.tmux.conf → スキップログ / 上書きしない
+#   - INSTALL_TMUX=0 / INSTALL_ZELLIJ=0 → no-op（何も呼ばない）
+#   - INSTALL_ZELLIJ=1 → mise_use_global("zellij@...") が呼ばれる
+#
+# NOTE: macOS 経路（INSTALL_TMUX=1 でも apt を呼ばず notice のみ）は
+# scripts/lib/install-multiplexer.sh ではなく scripts/setup-local-macos.sh
+# 内の同名関数で実装されている（lib 化されていない）。
+# canary-macos workflow が weekly に macOS ランナーで実行カバーするため、
+# bats 化は当面 deferred。lib 化された折に本ファイルへテスト追加すること。
+# =======================================================================
+
+setup() {
+  SCRIPT_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+
+  # HOME を tempdir に差し替え（~/.tmux.conf の検査用）
+  export HOME="$BATS_TEST_TMPDIR/home"
+  mkdir -p "$HOME"
+
+  # モック呼び出しログ
+  export MOCK_LOG="$BATS_TEST_TMPDIR/mock.log"
+  : >"$MOCK_LOG"
+
+  # shellcheck disable=SC1091
+  source "$SCRIPT_ROOT/scripts/lib/install-multiplexer.sh"
+
+  # install_multiplexer_tools が呼ぶ外部関数を全てモック。
+  # source の後に定義しないと lib 内同名関数で上書きされるリスクは無いが
+  # （これらは lib 内では未定義の外部依存）、明示性のため後段で定義する。
+  apt_install_or_upgrade() {
+    echo "apt_install_or_upgrade $*" >>"$MOCK_LOG"
+    return 0
+  }
+  export -f apt_install_or_upgrade
+
+  ensure_mise_installed() {
+    echo "ensure_mise_installed" >>"$MOCK_LOG"
+    return 0
+  }
+  export -f ensure_mise_installed
+
+  mise_use_global() {
+    echo "mise_use_global $*" >>"$MOCK_LOG"
+    return 0
+  }
+  export -f mise_use_global
+
+  # tmux コマンドの存在検知をモック（command -v tmux が true を返すように）
+  # ~/.tmux.conf 書き出しブロックは `command -v tmux &>/dev/null` ガード下にある。
+  # PATH に偽 tmux を置く方が builtin command の override より堅牢。
+  mkdir -p "$BATS_TEST_TMPDIR/fake-bin"
+  cat >"$BATS_TEST_TMPDIR/fake-bin/tmux" <<'STUB'
+#!/bin/sh
+exit 0
+STUB
+  chmod +x "$BATS_TEST_TMPDIR/fake-bin/tmux"
+  export PATH="$BATS_TEST_TMPDIR/fake-bin:$PATH"
+}
+
+# ------------------------------------------------------------------
+# INSTALL_TMUX / INSTALL_ZELLIJ 未指定 → no-op
+# ------------------------------------------------------------------
+
+@test "install_multiplexer_tools: no-op when both flags are unset" {
+  unset INSTALL_TMUX
+  unset INSTALL_ZELLIJ
+
+  run install_multiplexer_tools
+  [ "$status" -eq 0 ]
+  [ ! -s "$MOCK_LOG" ]
+  [ ! -f "$HOME/.tmux.conf" ]
+}
+
+# ------------------------------------------------------------------
+# INSTALL_TMUX=0 / INSTALL_ZELLIJ=0 → no-op
+# ------------------------------------------------------------------
+
+@test "install_multiplexer_tools: no-op when both flags are 0" {
+  export INSTALL_TMUX=0
+  export INSTALL_ZELLIJ=0
+
+  run install_multiplexer_tools
+  [ "$status" -eq 0 ]
+  [ ! -s "$MOCK_LOG" ]
+  [ ! -f "$HOME/.tmux.conf" ]
+}
+
+# ------------------------------------------------------------------
+# INSTALL_TMUX=1 → apt_install_or_upgrade("tmux", ...) を呼ぶ
+# ------------------------------------------------------------------
+
+@test "install_multiplexer_tools: INSTALL_TMUX=1 invokes apt_install_or_upgrade" {
+  export INSTALL_TMUX=1
+  unset INSTALL_ZELLIJ
+
+  run install_multiplexer_tools
+  [ "$status" -eq 0 ]
+  grep -q "apt_install_or_upgrade tmux tmux tmux" "$MOCK_LOG"
+}
+
+# ------------------------------------------------------------------
+# INSTALL_TMUX=1 + ~/.tmux.conf 不在 → 新規作成、同梱内容書き込み
+# ------------------------------------------------------------------
+
+@test "install_multiplexer_tools: INSTALL_TMUX=1 creates ~/.tmux.conf when absent" {
+  export INSTALL_TMUX=1
+  unset INSTALL_ZELLIJ
+
+  [ ! -f "$HOME/.tmux.conf" ]
+
+  run install_multiplexer_tools
+  [ "$status" -eq 0 ]
+  [ -f "$HOME/.tmux.conf" ]
+  grep -q 'tmux-256color' "$HOME/.tmux.conf"
+  [[ "$output" == *"~/.tmux.conf を作成しました"* ]]
+}
+
+# ------------------------------------------------------------------
+# INSTALL_TMUX=1 + ~/.tmux.conf 既存 → 上書きしない、スキップログ
+# （audit gap δ-1: PR #150 の手動テスト項目 #2 を自動化）
+# ------------------------------------------------------------------
+
+@test "install_multiplexer_tools: INSTALL_TMUX=1 respects pre-existing ~/.tmux.conf" {
+  export INSTALL_TMUX=1
+  unset INSTALL_ZELLIJ
+
+  local sentinel="# SENTINEL: pre-existing user config"
+  cat >"$HOME/.tmux.conf" <<EOF
+$sentinel
+set -g status-bg colour234
+EOF
+
+  run install_multiplexer_tools
+  [ "$status" -eq 0 ]
+
+  # 既存ファイルが保持されている（sentinel が残っている）
+  grep -qF "$sentinel" "$HOME/.tmux.conf"
+  # 同梱内容（tmux-256color）が混入していない
+  ! grep -q 'tmux-256color' "$HOME/.tmux.conf"
+  # スキップログが出ている
+  [[ "$output" == *"上書きしません"* ]]
+}
+
+# ------------------------------------------------------------------
+# INSTALL_ZELLIJ=1 → ensure_mise_installed + mise_use_global を呼ぶ
+# ------------------------------------------------------------------
+
+@test "install_multiplexer_tools: INSTALL_ZELLIJ=1 invokes mise_use_global" {
+  unset INSTALL_TMUX
+  export INSTALL_ZELLIJ=1
+
+  run install_multiplexer_tools
+  [ "$status" -eq 0 ]
+  grep -q "ensure_mise_installed" "$MOCK_LOG"
+  grep -q "mise_use_global zellij@" "$MOCK_LOG"
+  # tmux 経路は呼ばれない
+  ! grep -q "apt_install_or_upgrade" "$MOCK_LOG"
+  [ ! -f "$HOME/.tmux.conf" ]
+}
+
+# ------------------------------------------------------------------
+# INSTALL_TMUX=1 + INSTALL_ZELLIJ=1 → 両経路が呼ばれる
+# ------------------------------------------------------------------
+
+@test "install_multiplexer_tools: both flags trigger both code paths" {
+  export INSTALL_TMUX=1
+  export INSTALL_ZELLIJ=1
+
+  run install_multiplexer_tools
+  [ "$status" -eq 0 ]
+  grep -q "mise_use_global zellij@" "$MOCK_LOG"
+  grep -q "apt_install_or_upgrade tmux tmux tmux" "$MOCK_LOG"
+  [ -f "$HOME/.tmux.conf" ]
+}

--- a/tests/unit/install-multiplexer.bats
+++ b/tests/unit/install-multiplexer.bats
@@ -19,6 +19,9 @@
 # bats 化は当面 deferred。lib 化された折に本ファイルへテスト追加すること。
 # =======================================================================
 
+# `run !` 形式（bats >= 1.5.0）を使う。SC2314 回避のため。
+bats_require_minimum_version 1.5.0
+
 setup() {
   SCRIPT_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
 
@@ -144,10 +147,14 @@ EOF
 
   # 既存ファイルが保持されている（sentinel が残っている）
   grep -qF "$sentinel" "$HOME/.tmux.conf"
-  # 同梱内容（tmux-256color）が混入していない
-  ! grep -q 'tmux-256color' "$HOME/.tmux.conf"
   # スキップログが出ている
   [[ "$output" == *"上書きしません"* ]]
+  # 同梱内容（tmux-256color）が混入していないこと。
+  # NOTE: bats の `! cmd` は POSIX 例外で set -e から除外され、mid-test の
+  # `! grep` は silently swallow される（SC2314）。`run !` 形式（bats >= 1.5.0）
+  # で「cmd が non-zero 終了することを assert」する。grep -q が見つけてしまうと
+  # bats が即 fail を報告する（追加の assert 不要）。
+  run ! grep -q 'tmux-256color' "$HOME/.tmux.conf"
 }
 
 # ------------------------------------------------------------------
@@ -162,9 +169,10 @@ EOF
   [ "$status" -eq 0 ]
   grep -q "ensure_mise_installed" "$MOCK_LOG"
   grep -q "mise_use_global zellij@" "$MOCK_LOG"
-  # tmux 経路は呼ばれない
-  ! grep -q "apt_install_or_upgrade" "$MOCK_LOG"
   [ ! -f "$HOME/.tmux.conf" ]
+  # tmux 経路は呼ばれない（SC2314 回避: `run !` で「cmd が fail することを assert」）。
+  # grep -q が apt_install_or_upgrade を見つけてしまうと bats が即 fail を報告する。
+  run ! grep -q "apt_install_or_upgrade" "$MOCK_LOG"
 }
 
 # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes three audit gaps (delta-1, delta-2, delta-3) surfaced by the comprehensive test audit. **Test-only changes** — no behavior modifications to production scripts.

### Gap delta-1: PR #150 manual cases unautomated

PR #150 (tmux + `.tmux.conf`) test plan listed three scenarios but only the **new-file** branch was automated. This PR closes two of them:

- **Existing `~/.tmux.conf` respected** (`scripts/lib/install-multiplexer.sh:41` branch): added 4th integration run in `tests/integration/entrypoint.sh` that pre-creates `~/.tmux.conf` with a sentinel line, re-runs `INSTALL_TMUX=1 install.sh local`, then asserts the sentinel survives and the bundled `tmux-256color` content is NOT mixed in, plus the skip log (`上書きしません`) is emitted.
- **Unit-level coverage**: new `tests/unit/install-multiplexer.bats` (7 cases) mocks `apt_install_or_upgrade` / `mise_use_global` / `ensure_mise_installed` and verifies the no-op / tmux-only / zellij-only / both / pre-existing-file branches.

**macOS skip path deferred**: the function `install_multiplexer_tools` for macOS lives in `scripts/setup-local-macos.sh:119` (NOT in the lib — only the Linux variant is lib-ified). bats-isolating it requires extracting the function from a top-level-executing script, so we punt; the `canary-macos` weekly workflow already covers this path. A header comment in the new bats file documents this deferral.

### Gap delta-2: smoke `bash -n` did not cover `scripts/lib/*.sh`

`tests/smoke/run.sh` syntax-checked only 6 top-level scripts. The 17 `scripts/lib/*.sh` files were unverified at smoke layer, so a `bash -n` error in any lib slipped smoke and surfaced only when integration sourced it. Extended the syntax loop to glob `scripts/lib/*.sh` (one assertion per lib, currently 17 new pass lines).

### Gap delta-3: doctor exit code spec unasserted

`README §6.5.2` specifies `scripts/doctor.sh` returns 0 / 1 / 2. Nothing asserted this. Added a minimal smoke check: run doctor, accept exit 0 or 1 (a fresh worktree often warns), fail on any other code (catches exit 2 = errors and any out-of-spec value).

## Files changed

- `tests/integration/entrypoint.sh` — +57 lines (4th run for `.tmux.conf` respect)
- `tests/smoke/run.sh` — +27 lines (lib syntax loop + doctor exit code check)
- `tests/unit/install-multiplexer.bats` — new file, 7 bats cases

## Test plan

- [x] `bats tests/unit/install-multiplexer.bats` — 7/7 pass
- [x] `bats tests/unit/` (all suites) — 68/68 pass (61 existing + 7 new)
- [x] `bash tests/smoke/run.sh` — 33/33 pass (was 15 before, +17 lib syntax +1 doctor exit)
- [x] `bash -n tests/integration/entrypoint.sh` — syntax OK (full integration run depends on Docker CI)
- [x] `lefthook run pre-commit` — clean (shfmt + shellcheck + trivy + gitleaks all pass)
- [x] commitlint — pass

## Out of scope

- No changes to `scripts/lib/install-multiplexer.sh` (test-only PR)
- No README / docs changes
- macOS bats coverage deferred (function not lib-ified; covered by canary-macos)
- No broad bats expansion for the other 11 uncovered libs (focused fix per audit gap; separate batch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)