### PR TITLE
chore: post-rename followups (docs sync + AGENTYARD_REF coverage)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,9 @@
 - `/review` — コード変更や PR をレビュー
 - `/ship` — lint・コミット・PR 作成を一括実行
 - `/drive` — implement + ship + review loop（Issue から merge-ready な PR まで自律駆動）
+- `/health` — リポジトリ状態（working tree, stash, branch, worktree, PR, issue, actions 等）の 16 領域ステータス点検
+- `/phase-issue` — Phase-N tracking issue を構造化された body で起票
+- `/topics` — GitHub topics 候補を選定・検証して適用
 
 ## Skills の共通ルール
 

--- a/install.sh
+++ b/install.sh
@@ -205,4 +205,8 @@ main() {
   run_local "$target" "$extracted_dir"
 }
 
-main "$@"
+# Allow this file to be `source`d (e.g. from bats unit tests) without
+# triggering main(). When executed directly, BASH_SOURCE[0] equals $0.
+if [ "${BASH_SOURCE[0]:-$0}" = "$0" ]; then
+  main "$@"
+fi

--- a/tests/unit/install-config.bats
+++ b/tests/unit/install-config.bats
@@ -1,0 +1,72 @@
+#!/usr/bin/env bats
+# shellcheck disable=SC2016
+# =======================================================================
+# tests/unit/install-config.bats
+# -----------------------------------------------------------------------
+# install.sh の DEFAULT_REF 解決ロジックを検証する。
+#
+# Precedence chain (install.sh:6):
+#   AGENTYARD_REF (canonical)
+#     > AGENTIC_BOOTSTRAP_REF (legacy 1)
+#     > BOOTSTRAP_REF (legacy 2)
+#     > "main" (fallback default)
+#
+# 各ケースは bash -c で subshell を起動し、install.sh を source する。
+# 親プロセスで readonly が collide しないよう subshell 内で完結させる。
+# install.sh は末尾の BASH_SOURCE ガードにより source 時は main() を実行しない。
+# =======================================================================
+
+setup() {
+  SCRIPT_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+}
+
+_resolve_default_ref() {
+  # 親環境の REF 系を意図せず継承しないよう env -i で隔離。
+  # PATH と HOME は bash 起動に必要なため明示的に引き渡す。
+  env -i \
+    PATH="$PATH" \
+    HOME="$HOME" \
+    "$@" \
+    bash -c "source '$SCRIPT_ROOT/install.sh' && printf '%s' \"\$DEFAULT_REF\""
+}
+
+@test "DEFAULT_REF: fallback to 'main' when no env var is set" {
+  result="$(_resolve_default_ref)"
+  [ "$result" = "main" ]
+}
+
+@test "DEFAULT_REF: BOOTSTRAP_REF (legacy 2) is honored when only it is set" {
+  result="$(_resolve_default_ref BOOTSTRAP_REF=legacy2-ref)"
+  [ "$result" = "legacy2-ref" ]
+}
+
+@test "DEFAULT_REF: AGENTIC_BOOTSTRAP_REF (legacy 1) takes precedence over BOOTSTRAP_REF" {
+  result="$(_resolve_default_ref AGENTIC_BOOTSTRAP_REF=legacy1-ref BOOTSTRAP_REF=legacy2-ref)"
+  [ "$result" = "legacy1-ref" ]
+}
+
+@test "DEFAULT_REF: AGENTYARD_REF (canonical) takes precedence over both legacy names" {
+  result="$(_resolve_default_ref AGENTYARD_REF=canonical-ref AGENTIC_BOOTSTRAP_REF=legacy1-ref BOOTSTRAP_REF=legacy2-ref)"
+  [ "$result" = "canonical-ref" ]
+}
+
+@test "DEFAULT_REF: AGENTYARD_REF wins even when legacy 1 is set" {
+  result="$(_resolve_default_ref AGENTYARD_REF=canonical-ref AGENTIC_BOOTSTRAP_REF=legacy1-ref)"
+  [ "$result" = "canonical-ref" ]
+}
+
+@test "DEFAULT_REF: AGENTYARD_REF wins even when only legacy 2 is set alongside" {
+  result="$(_resolve_default_ref AGENTYARD_REF=canonical-ref BOOTSTRAP_REF=legacy2-ref)"
+  [ "$result" = "canonical-ref" ]
+}
+
+@test "DEFAULT_REF: empty AGENTYARD_REF falls through to AGENTIC_BOOTSTRAP_REF" {
+  # ${VAR:-...} は VAR が unset OR empty のとき fallback する仕様
+  result="$(_resolve_default_ref AGENTYARD_REF= AGENTIC_BOOTSTRAP_REF=legacy1-ref)"
+  [ "$result" = "legacy1-ref" ]
+}
+
+@test "DEFAULT_REF: all empty falls through to 'main'" {
+  result="$(_resolve_default_ref AGENTYARD_REF= AGENTIC_BOOTSTRAP_REF= BOOTSTRAP_REF=)"
+  [ "$result" = "main" ]
+}


### PR DESCRIPTION
## Summary

PR #166 (リネーム) の post-audit で見つかった 2 件の followup:

1. **docs(claude)**: `.claude/skills/` 実装に対して `CLAUDE.md` の Available Skills 一覧が 5 件欠落していた → user-invocable な `/health` `/phase-issue` `/topics` の 3 件を補完。internal-only な `lint-rules` / `commit-conventions` は global CLAUDE.md の方針に従い不掲載。
2. **test(install)**: env var の legacy fallback chain で `AGENTYARD_ASSUME_YES` 側は precedence テスト充実、一方 `AGENTYARD_REF` 側は **テスト 0 件** の非対称があった → `tests/unit/install-config.bats` を新規追加し 8 ケースで `AGENTYARD_REF > AGENTIC_BOOTSTRAP_REF > BOOTSTRAP_REF > "main"` を全網羅。

副次的に `install.sh` 末尾に `BASH_SOURCE[0] = "$0"` ガードを追加（source 時に main() を起動しないため、bats が subshell sourcing で `DEFAULT_REF` を inspect 可能になる）。実行時挙動は変更なし。

## Test plan

- [x] `bats tests/unit/install-config.bats` — 新規 8 件 pass
- [x] `bats tests/unit/` — 既存 72 件含む全 80 件 pass (regression なし)
- [x] `bash tests/smoke/run.sh` — 全 40 件 pass
- [x] `lefthook run pre-commit` — shellcheck / shfmt / markdownlint / trivy / gitleaks すべて pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)