### PR TITLE
chore(deps): sync commons to 36408c3

### DIFF
--- a/.commons/sync.yaml
+++ b/.commons/sync.yaml
@@ -1,7 +1,7 @@
 # Auto-updated by commons sync.sh
 # 'pinned' is user-editable — add or remove paths freely
-commit: f628f1f046786fc08775e4691d6840f0710123fc
-synced_at: 2026-05-25T00:53:35Z
+commit: 36408c33296295380647cd68934002328402aaef
+synced_at: 2026-06-07T02:43:51Z
 
 # Skills sync (opt-in). Add adapter ids to skills_adapters and a SHA
 # to skills_commit. The skills repo's main HEAD SHA can be obtained via:

--- a/lefthook-base.yaml
+++ b/lefthook-base.yaml
@@ -24,7 +24,7 @@
 #         glob: "**/*.sh"
 #         run: <your replacement command>
 #
-# See ozzy-labs/agentyard#130 for a working example.
+# See ozzy-labs/agentic-bootstrap#130 for a working example.
 
 glob_matcher: doublestar
 


### PR DESCRIPTION
## Summary

ozzy-labs/commons HEAD `36408c3` を本リポに同期。

- `.commons/sync.yaml` の `commit` を `36408c33296295380647cd68934002328402aaef` に bump
- 対応する `dist/` を sync

## Synced via

`commons/scripts/sync-consumers.sh` (push 型同期、ozzy-labs/skills#80 epic)