### PR TITLE
feat: add opt-in Bun runtime (INSTALL_BUN) via mise

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -59,7 +59,7 @@ agentyard/
 - 🤖 **AI エージェント CLI** - Claude Code / Codex CLI / GitHub Copilot CLI / Gemini CLI（個別選択可）
 - 🧠 **AI パワーツール** - markitdown（PDF/Office → Markdown）/ tesseract-ocr(+jpn) / ffmpeg / ast-grep（構造的コード検索）/ yq
 - 🐳 **コンテナ / サンドボックス基盤** - Docker Engine + Docker Compose（Dev Container の前提）+ bubblewrap
-- ⚡ **統一バージョン管理** - mise で Node.js LTS / pnpm / Python / uv / gitleaks / shellcheck / ast-grep / yq を一元管理
+- ⚡ **統一バージョン管理** - mise で Node.js LTS / pnpm / Python / uv / gitleaks / shellcheck / ast-grep / yq を一元管理（opt-in: Bun-native ツール向けに Bun）
 - 🐍 **Python エコシステム** - mise 管理の Python + uv（パッケージ・venv・CLI ツール）
 - ☁️ **クラウド CLI** - AWS CLI v2（デフォルト ON）/ Azure CLI, Google Cloud CLI（opt-in）
 - 🔒 **モダンなシークレット / 脆弱性スキャン** - gitleaks（2026 デファクト シークレットスキャナ）+ trivy（ファイルシステム脆弱性スキャナ。本リポの lefthook pre-commit で利用）を mise で導入、プロジェクト側の lefthook と連携
@@ -181,6 +181,7 @@ cd agentyard
 | `INSTALL_GIT_TOOLS` | `1` | Git, GitHub CLI, gitleaks |
 | `INSTALL_NODE` | `1` | mise + Node.js LTS + pnpm |
 | `INSTALL_PYTHON` | `1` | mise + Python + uv |
+| `INSTALL_BUN` | `0` | Bun（mise、opt-in）— JS ランタイム / パッケージマネージャ / バンドラ |
 | `INSTALL_CONTAINER` | `1` | Docker Engine, Docker Compose, bubblewrap |
 | `INSTALL_AWS_CLI` | `1` | AWS CLI v2 |
 | `INSTALL_AZURE_CLI` | `0` | Azure CLI（opt-in） |
@@ -206,6 +207,7 @@ macOS 版は意図的に軽量化されている — Docker Desktop / AI エー�
 | `INSTALL_DEV_TOOLS` | `1` | just, zoxide, shellcheck, chezmoi |
 | `INSTALL_TMUX` | `0` | macOS では notice のみ表示。必要なら `brew install tmux` |
 | `INSTALL_ZELLIJ` | `0` | Zellij（mise 経由、opt-in） |
+| `INSTALL_BUN` | `0` | Bun（mise 経由、opt-in）— JS ランタイム / パッケージマネージャ / バンドラ |
 
 例 — Linux で非対話・Azure CLI 追加・AI エージェント CLI を全部スキップ:
 
@@ -353,6 +355,7 @@ Ubuntu/Debian 環境（WSL2 + 非 WSL Linux：Ubuntu Server / EC2 / GCE / コン
 4. **Node.js エコシステム（mise 経由）**
    - **Node.js LTS** - JavaScript ランタイム
    - **pnpm** - 高速なパッケージマネージャー
+   - **Bun**（mise 経由、opt-in）- オールインワンの JS ランタイム / パッケージマネージャ / バンドラ（`INSTALL_BUN=1` または対話セレクタで選択）。`bun:sqlite` を使う MCP サーバ等、Node/`npx` では動かない Bun-native ツールを動かすために必要。Node + pnpm の置き換えではなく**追加**の選択肢で、`bun@1` メジャーにピン（mise core backend、Node/Python と同じレンジ運用）。global mise config テンプレートには**意図的に列挙しない**真の opt-in のため、既定ホストには入らない。
 5. **Python エコシステム（mise 経由）**
    - **Python** - mise 管理の最新安定版
    - **uv** - パッケージ・仮想環境・CLI ツール導入

--- a/README.ja.md
+++ b/README.ja.md
@@ -615,6 +615,7 @@ SETUP_LOG=/tmp/setup.log ./install.sh local
 - **markitdown[all]**（`uv tool install` 経由）
 - **just / zoxide / shellcheck / chezmoi**（mise 経由）— 開発補助（chezmoi は `dotfiles/` テンプレートを適用、ADR-0003 準拠）
 - **zellij**（mise 経由）— ターミナルマルチプレクサ（opt-in。`INSTALL_ZELLIJ=1` を設定）
+- **Bun**（mise 経由）— JS ランタイム / パッケージマネージャ / バンドラ（opt-in。`INSTALL_BUN=1` を設定）。global mise config テンプレートに意図的に列挙しないため chezmoi apply の後に登録する（ADR-0002 参照）
 
 **6.3.2 自動化対象外（macOS では手動）**
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ agentyard/
 - 🤖 **AI Agent CLIs** - Claude Code, Codex CLI, GitHub Copilot CLI, Gemini CLI (choose individually)
 - 🧠 **AI Power Tools** - markitdown (PDF/Office → Markdown), tesseract-ocr (+jpn), ffmpeg, ast-grep (structural code search), yq
 - 🐳 **Container / Sandbox Foundation** - Docker Engine + Docker Compose (essential for Dev Containers) + bubblewrap
-- ⚡ **Unified Version Manager** - mise manages Node.js LTS / pnpm / Python / uv / gitleaks / shellcheck / ast-grep / yq
+- ⚡ **Unified Version Manager** - mise manages Node.js LTS / pnpm / Python / uv / gitleaks / shellcheck / ast-grep / yq (opt-in: Bun for Bun-native tooling)
 - 🐍 **Python Ecosystem** - mise-managed Python + uv for packages/venvs/CLI tools
 - ☁️ **Cloud CLIs** - AWS CLI v2 (default) / Azure CLI, Google Cloud CLI (opt-in)
 - 🔒 **Modern Secret / Vulnerability Scanning** - gitleaks (2026 de-facto secret scanner) + trivy (filesystem vuln scanner, used by this repo's lefthook pre-commit); pair with lefthook per project
@@ -181,6 +181,7 @@ Each flag accepts `1` (install) or `0` (skip). Defaults shown match `scripts/set
 | `INSTALL_GIT_TOOLS` | `1` | Git, GitHub CLI, gitleaks |
 | `INSTALL_NODE` | `1` | mise + Node.js LTS + pnpm |
 | `INSTALL_PYTHON` | `1` | mise + Python + uv |
+| `INSTALL_BUN` | `0` | Bun (mise, opt-in) — JS runtime / package manager / bundler |
 | `INSTALL_CONTAINER` | `1` | Docker Engine, Docker Compose, bubblewrap |
 | `INSTALL_AWS_CLI` | `1` | AWS CLI v2 |
 | `INSTALL_AZURE_CLI` | `0` | Azure CLI (opt-in) |
@@ -206,6 +207,7 @@ macOS is intentionally lighter — Docker Desktop / AI agent CLIs / cloud CLIs a
 | `INSTALL_DEV_TOOLS` | `1` | just, zoxide, shellcheck, chezmoi |
 | `INSTALL_TMUX` | `0` | macOS prints a notice only — install via `brew install tmux` |
 | `INSTALL_ZELLIJ` | `0` | Zellij (via mise, opt-in) |
+| `INSTALL_BUN` | `0` | Bun (via mise, opt-in) — JS runtime / package manager / bundler |
 
 Example — non-interactive Linux install with Azure CLI added and AI agent CLIs skipped:
 
@@ -353,6 +355,7 @@ You can run it either through `install.sh` or directly via `scripts/setup-local-
 4. **Node.js Ecosystem (via mise)**
    - **Node.js LTS** - JavaScript runtime
    - **pnpm** - Fast package manager
+   - **Bun** (via mise, opt-in) - All-in-one JS runtime / package manager / bundler (set `INSTALL_BUN=1` or select interactively). Needed for Bun-native tools such as MCP servers that use `bun:sqlite` and won't run on Node/`npx`. An *additional* choice, not a replacement for Node + pnpm; pinned to the `bun@1` major (mise core backend, same range policy as Node/Python). Genuinely opt-in: it is intentionally **not** listed in the global mise config template, so default hosts stay Bun-free.
 5. **Python Ecosystem (via mise)**
    - **Python** - Latest stable via mise
    - **uv** - Packaging, virtualenvs, and CLI tool installer

--- a/README.md
+++ b/README.md
@@ -615,6 +615,7 @@ macOS counterpart to `setup-local-linux.sh`, intentionally lighter-weight: focus
 - **markitdown[all]** (via `uv tool install`)
 - **just / zoxide / shellcheck / chezmoi** (via mise) — dev helpers (chezmoi applies `dotfiles/` templates per ADR-0003)
 - **zellij** (via mise) — terminal multiplexer (opt-in; set `INSTALL_ZELLIJ=1`)
+- **Bun** (via mise) — JS runtime / package manager / bundler (opt-in; set `INSTALL_BUN=1`). Registered after the chezmoi apply since it is intentionally not in the global mise config template (see ADR-0002)
 
 **6.3.2 What Is NOT Installed (manual on macOS)**
 

--- a/docs/adr/ADR-0002-tool-selection.md
+++ b/docs/adr/ADR-0002-tool-selection.md
@@ -32,6 +32,14 @@
 - `pnpm@<pinned>` — pnpm（aqua バックエンド、具体パッチ版にピン）
 - `python@latest` — Python（core バックエンド、レンジ指定例外）
 
+### JS ランタイム（opt-in）
+
+- `bun@1` — Bun（core バックエンド、レンジ指定。**既定 OFF**、`INSTALL_BUN=1` で有効化）
+  - **採用理由**: Bun-native な MCP サーバ（`bun:sqlite` を使うアプリは `npx`/Node では動かない）をホスト直で動かす需要がある。エコシステムの主流は依然 Node + `npx` のため Bun を **既定 ON にはせず**、AI-first ツール群を動かしたいユーザー向けの opt-in に留める（Node + pnpm の置き換えではなく追加の選択肢）。
+  - **ピン運用**: bun は mise の core バックエンド扱いのため、node / python と同じ **レンジ指定例外**に乗る（aqua レジストリ追従ずれ・具体パッチ版ピン・Renovate churn の対象外）。
+  - **真の opt-in 設計（global config テンプレート非掲載）**: `dotfiles/dot_config/mise/config.toml` に列挙すると `install_dev_tools` 末尾の `mise install` で **全ホストに入り opt-in でなくなる**（trivy が同経路で全員に入るのと同じ挙動）。これを避けるため bun はテンプレートに**意図的に列挙しない**。一方 `chezmoi apply` は global config を上書きするため、apply より前に `mise use --global bun@1` すると登録が消える（ADR-0003 / #153・#156 の wipe 罠）。対策として `install_bun` を **`install_dev_tools`（＝最後の `chezmoi apply`）より後**に呼び、apply 後に登録することで wipe を回避しつつテンプレート非掲載を両立する。
+  - **doctor 非対象**: opt-in のため `check_mise_managed_tools` の必須リスト（node/pnpm/python/uv）には**含めない**（zellij と同様。含めると未導入ホストで誤 warning になる）。
+
 ### Git / security
 
 - `gitleaks` — シークレットスキャン（lefthook pre-commit で実行）

--- a/scripts/lib/install-languages.sh
+++ b/scripts/lib/install-languages.sh
@@ -40,6 +40,31 @@ install_mise_and_languages() {
   echo "✅ mise + 言語環境インストール完了"
 }
 
+# 4b. Bun（opt-in）のインストール
+# Bun-native な MCP サーバ等（bun:sqlite を使うアプリは npx/Node では動かない）を
+# ホスト直で動かすための opt-in ランタイム / パッケージマネージャ / バンドラ。
+# 既定 OFF（INSTALL_BUN=1 で有効化）。Node + pnpm の代替ではなく追加の選択肢。
+#
+# バージョン方針: bun は mise の core backend 扱いのため、node / python と同じ
+# レンジ指定の例外に乗る（aqua レジストリ追従ずれ・具体パッチ版ピンの対象外）。
+#
+# 重要（呼び出し順序の制約）: 本関数は install_dev_tools の `chezmoi apply` より
+# 後に呼ぶこと。bun は真の opt-in であり global mise config テンプレート
+# (dotfiles/dot_config/mise/config.toml) には**意図的に列挙しない**（列挙すると
+# 末尾の `mise install` で全ホストに入り opt-in でなくなる）。一方 chezmoi apply は
+# global config を上書きするため、apply より前に `mise use --global` すると bun の
+# 登録が消える（ADR-0003 / #153・#156 と同じ罠）。apply 後に登録することで回避する。
+install_bun() {
+  [ "${INSTALL_BUN:-0}" != "1" ] && return
+
+  ensure_mise_installed || return 1
+
+  echo ""
+  echo "🍞 Bun を mise でインストール中..."
+  mise_use_global "bun@1" "Bun"
+  echo "✅ Bun インストール完了"
+}
+
 # 5. Git セキュリティツール（gitleaks）のインストール
 # git-secrets（メンテ停滞）の後継として gitleaks を mise 経由で導入
 install_git_security_tools() {

--- a/scripts/setup-local-linux.sh
+++ b/scripts/setup-local-linux.sh
@@ -30,6 +30,7 @@ INSTALL_GIT_TOOLS="${INSTALL_GIT_TOOLS:-1}"     # Git, GitHub CLI, gitleaks
 # プログラミング言語環境（mise で統一管理）
 INSTALL_NODE="${INSTALL_NODE:-1}"     # mise + Node.js LTS + pnpm
 INSTALL_PYTHON="${INSTALL_PYTHON:-1}" # mise + Python + uv
+INSTALL_BUN="${INSTALL_BUN:-0}"       # mise + Bun（opt-in、JS ランタイム/パッケージマネージャ）
 
 # コンテナ / サンドボックスツール
 INSTALL_CONTAINER="${INSTALL_CONTAINER:-1}" # Docker, Docker Compose, bubblewrap
@@ -161,6 +162,7 @@ echo "  🔧 ビルドツール - build-essential"
 echo "  🔧 Git関連ツール - Git, GitHub CLI, gitleaks"
 echo "  📦 Node.js環境 - mise, Node.js LTS, pnpm"
 echo "  🐍 Python環境 - mise, Python, uv"
+echo "  🍞 Bun (opt-in) - mise, Bun ランタイム / パッケージマネージャ"
 echo "  🐳 コンテナ / サンドボックスツール - Docker Engine, Docker Compose, bubblewrap"
 echo "  ☁️ クラウドツール - AWS CLI (default) / Azure CLI, Google Cloud CLI (opt-in)"
 echo "  🪟 Terminal multiplexer - tmux / zellij (opt-in)"
@@ -208,6 +210,10 @@ if [[ ! $INSTALL_ALL =~ ^[Yy]?$ ]]; then
   _prompt_default_yes "🐍 Python環境 (mise, Python, uv) をインストールしますか? [Y/n]: "
   echo ""
   [[ $REPLY =~ ^[Nn]$ ]] && INSTALL_PYTHON=0
+
+  _prompt_default_no "🍞 Bun (mise, JS ランタイム/パッケージマネージャ, opt-in) をインストールしますか? [y/N]: "
+  echo ""
+  [[ $REPLY =~ ^[Yy]$ ]] && INSTALL_BUN=1
 
   _prompt_default_yes "🐳 コンテナ / サンドボックスツール (Docker, Docker Compose, bubblewrap) をインストールしますか? [Y/n]: "
   echo ""
@@ -467,7 +473,7 @@ echo "✅ 依存パッケージインストール完了"
 # 1. ビルド → 2. 基本CLI → 3. Git (git, gh) → 4. mise + 言語環境
 # → 5. Git セキュリティ (gitleaks) → 6. コンテナ / サンドボックス → 7. クラウド
 # → 8. Terminal multiplexer (opt-in) → 9. AIエージェント
-# → 10. AI パワーツール → 11. 開発補助
+# → 10. AI パワーツール → 11. 開発補助 → 12. Bun (opt-in)
 
 install_build_tools
 install_basic_cli_tools
@@ -483,6 +489,11 @@ install_multiplexer_tools
 install_ai_tools
 install_ai_power_tools
 install_dev_tools
+# Bun (opt-in) は install_dev_tools の `chezmoi apply`（global mise config を上書き）
+# より後に登録する必要がある。bun は global config テンプレートに意図的に
+# 列挙していない真の opt-in のため、apply 前に登録すると wipe される。
+# 詳細は scripts/lib/install-languages.sh の install_bun ヘッダを参照。
+install_bun
 
 # ========================================
 # 6. 環境設定（PATH、Git設定等）
@@ -607,6 +618,7 @@ echo ""
 echo "  📦 Node.js エコシステム:"
 echo "    Node.js:        $(node --version 2>/dev/null || echo '未インストール')"
 echo "    pnpm:           $(pnpm --version 2>/dev/null || echo '未インストール')"
+echo "    Bun:            $(bun --version 2>/dev/null || echo '未インストール (opt-in)')"
 echo ""
 echo "  🐍 Python エコシステム:"
 echo "    Python:         $(python3 --version 2>/dev/null || echo '未インストール')"

--- a/scripts/setup-local-macos.sh
+++ b/scripts/setup-local-macos.sh
@@ -29,6 +29,7 @@ INSTALL_AI_POWER_TOOLS="${INSTALL_AI_POWER_TOOLS:-1}" # ast-grep, yq, markitdown
 INSTALL_DEV_TOOLS="${INSTALL_DEV_TOOLS:-1}"           # just, zoxide, shellcheck, chezmoi
 INSTALL_TMUX="${INSTALL_TMUX:-0}"                     # tmux（macOS では自動化対象外、READMEの手動案内のみ）
 INSTALL_ZELLIJ="${INSTALL_ZELLIJ:-0}"                 # Zellij（opt-in、mise 経由）
+INSTALL_BUN="${INSTALL_BUN:-0}"                       # Bun（opt-in、mise 経由、JS ランタイム/パッケージマネージャ）
 
 # スクリプトのディレクトリ
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -133,6 +134,25 @@ install_multiplexer_tools() {
   mise_use_global "zellij@0.44.3" "Zellij"
 }
 
+# Bun（opt-in、JS ランタイム / パッケージマネージャ / バンドラ、mise 経由）
+# Bun-native な MCP サーバ等（bun:sqlite を使うアプリは npx/Node では動かない）を
+# ホスト直で動かすための opt-in ランタイム（既定 OFF、INSTALL_BUN=1 で有効化）。
+# bun は mise core backend 扱いのため node / python と同じレンジ指定でピンする。
+#
+# 重要（呼び出し順序の制約）: 本関数は install_dev_tools の `chezmoi apply` より
+# 後に呼ぶこと。bun は真の opt-in であり global mise config テンプレートには
+# 意図的に列挙しないため、apply 前に登録すると上書きで消える（Linux 側
+# scripts/lib/install-languages.sh の install_bun ヘッダと同じ理由）。
+install_bun() {
+  [ "${INSTALL_BUN:-0}" != "1" ] && return
+
+  ensure_mise_installed || return 1
+
+  echo ""
+  echo "🍞 Bun を mise でインストール中..."
+  mise_use_global "bun@1" "Bun"
+}
+
 # 開発補助ツール: just / zoxide / shellcheck / chezmoi（mise）
 install_dev_tools() {
   [ "$INSTALL_DEV_TOOLS" != "1" ] && return
@@ -230,6 +250,9 @@ install_git_security_tools
 install_ai_power_tools
 install_multiplexer_tools
 install_dev_tools
+# Bun (opt-in) は install_dev_tools の `chezmoi apply` 後に登録する（global mise
+# config テンプレート非掲載の真の opt-in のため、apply 前だと wipe される）。
+install_bun
 
 # ========================================
 # セットアップ完了サマリー
@@ -245,6 +268,7 @@ echo ""
 echo "📦 言語ランタイム:"
 echo "  Node.js:        $(_mise_at_home exec node@lts -- node --version 2>/dev/null || echo '未インストール')"
 echo "  pnpm:           $(_mise_at_home exec pnpm -- pnpm --version 2>/dev/null || echo '未インストール')"
+echo "  Bun:            $(_mise_at_home exec bun -- bun --version 2>/dev/null || echo '未インストール (opt-in)')"
 echo "  Python:         $(_mise_at_home exec python -- python3 --version 2>/dev/null || echo '未インストール')"
 echo "  uv:             $(_mise_at_home exec uv -- uv --version 2>/dev/null | head -n1 || echo '未インストール')"
 echo ""

--- a/tests/integration/assert-tools.sh
+++ b/tests/integration/assert-tools.sh
@@ -66,6 +66,13 @@ if [ "${INSTALL_CONTAINER:-1}" = "1" ]; then
   echo ""
 fi
 
+# Bun は opt-in（既定 OFF）。INSTALL_BUN=1 を明示したときだけ assert する。
+if [ "${INSTALL_BUN:-0}" = "1" ]; then
+  echo "🍞 Bun (opt-in)"
+  assert_tool "bun" bun --version
+  echo ""
+fi
+
 if [ "${INSTALL_TMUX:-0}" = "1" ] || [ "${INSTALL_ZELLIJ:-0}" = "1" ]; then
   echo "🪟 Terminal multiplexer"
   if [ "${INSTALL_TMUX:-0}" = "1" ]; then

--- a/tests/integration/entrypoint.sh
+++ b/tests/integration/entrypoint.sh
@@ -142,23 +142,25 @@ fi
 echo "✅ setup-zsh-linux.sh completes under pipe execution"
 
 printf '\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n'
-printf '🔵 3rd run — opt-in multiplexer (INSTALL_TMUX=1 INSTALL_ZELLIJ=1)\n'
+printf '🔵 3rd run — opt-in tools (INSTALL_TMUX=1 INSTALL_ZELLIJ=1 INSTALL_BUN=1)\n'
 printf '━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\n'
 
-# multiplexer は opt-in なので、既定の 1st / 2nd run では入らない。
-# 3rd run で INSTALL_TMUX=1 / INSTALL_ZELLIJ=1 を明示して両方がインストールされ、
-# assert-tools.sh が opt-in アサーションを満たすことを確認する。
-# tmux 側は ~/.tmux.conf の新規作成（既存ファイル無し時）も検証する。
-if ! INSTALL_TMUX=1 INSTALL_ZELLIJ=1 /workspace/install.sh local 2>&1 | tee "$RUN3_LOG"; then
-  echo "❌ 3rd run (INSTALL_TMUX=1 INSTALL_ZELLIJ=1) failed"
+# multiplexer / Bun は opt-in なので、既定の 1st / 2nd run では入らない。
+# 3rd run で INSTALL_TMUX=1 / INSTALL_ZELLIJ=1 / INSTALL_BUN=1 を明示して
+# すべてインストールされ、assert-tools.sh が opt-in アサーションを満たすことを
+# 確認する。tmux 側は ~/.tmux.conf の新規作成（既存ファイル無し時）も検証する。
+# Bun は global mise config テンプレート非掲載の真の opt-in のため、install_bun が
+# install_dev_tools の chezmoi apply 後に登録され wipe されないことの回帰検知も兼ねる。
+if ! INSTALL_TMUX=1 INSTALL_ZELLIJ=1 INSTALL_BUN=1 /workspace/install.sh local 2>&1 | tee "$RUN3_LOG"; then
+  echo "❌ 3rd run (INSTALL_TMUX=1 INSTALL_ZELLIJ=1 INSTALL_BUN=1) failed"
   exit 1
 fi
 assert_no_fatal_errors "$RUN3_LOG" "3rd run"
 
 # shellcheck disable=SC1091
 source "$HOME/.bashrc" || true
-if ! INSTALL_TMUX=1 INSTALL_ZELLIJ=1 bash "$ASSERT_SCRIPT"; then
-  echo "❌ Tool assertions failed after 3rd run (INSTALL_TMUX=1 INSTALL_ZELLIJ=1)"
+if ! INSTALL_TMUX=1 INSTALL_ZELLIJ=1 INSTALL_BUN=1 bash "$ASSERT_SCRIPT"; then
+  echo "❌ Tool assertions failed after 3rd run (INSTALL_TMUX=1 INSTALL_ZELLIJ=1 INSTALL_BUN=1)"
   exit 1
 fi
 

--- a/tests/unit/install-languages.bats
+++ b/tests/unit/install-languages.bats
@@ -1,0 +1,93 @@
+#!/usr/bin/env bats
+# =======================================================================
+# tests/unit/install-languages.bats
+# -----------------------------------------------------------------------
+# scripts/lib/install-languages.sh の install_bun 関数を検証する。
+# ensure_mise_installed / mise_use_global をモックして、外部依存
+# （mise, network）を一切呼ばない。
+#
+# 検証範囲:
+#   - INSTALL_BUN 未指定 / 0 → no-op（mise_use_global を呼ばない）
+#   - INSTALL_BUN=1 → ensure_mise_installed + mise_use_global("bun@...") を呼ぶ
+#
+# NOTE: install_bun は真の opt-in（既定 OFF）であり、global mise config
+# テンプレート (dotfiles/dot_config/mise/config.toml) には意図的に列挙しない。
+# このため install_dev_tools の chezmoi apply より後に呼ぶ前提だが、関数単体の
+# 振る舞い（フラグによる分岐）は呼び出し順序に依存しないためここで検証する。
+# =======================================================================
+
+bats_require_minimum_version 1.5.0
+
+setup() {
+  SCRIPT_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+
+  export MOCK_LOG="$BATS_TEST_TMPDIR/mock.log"
+  : >"$MOCK_LOG"
+
+  # shellcheck disable=SC1091
+  source "$SCRIPT_ROOT/scripts/lib/install-languages.sh"
+
+  ensure_mise_installed() {
+    echo "ensure_mise_installed" >>"$MOCK_LOG"
+    return 0
+  }
+  export -f ensure_mise_installed
+
+  mise_use_global() {
+    echo "mise_use_global $*" >>"$MOCK_LOG"
+    return 0
+  }
+  export -f mise_use_global
+}
+
+# ------------------------------------------------------------------
+# INSTALL_BUN 未指定 → no-op
+# ------------------------------------------------------------------
+
+@test "install_bun: no-op when INSTALL_BUN is unset" {
+  unset INSTALL_BUN
+
+  run install_bun
+  [ "$status" -eq 0 ]
+  [ ! -s "$MOCK_LOG" ]
+}
+
+# ------------------------------------------------------------------
+# INSTALL_BUN=0 → no-op
+# ------------------------------------------------------------------
+
+@test "install_bun: no-op when INSTALL_BUN=0" {
+  export INSTALL_BUN=0
+
+  run install_bun
+  [ "$status" -eq 0 ]
+  [ ! -s "$MOCK_LOG" ]
+}
+
+# ------------------------------------------------------------------
+# INSTALL_BUN=1 → ensure_mise_installed + mise_use_global("bun@...")
+# ------------------------------------------------------------------
+
+@test "install_bun: INSTALL_BUN=1 invokes mise_use_global with bun" {
+  export INSTALL_BUN=1
+
+  run install_bun
+  [ "$status" -eq 0 ]
+  grep -q "ensure_mise_installed" "$MOCK_LOG"
+  grep -q "mise_use_global bun@" "$MOCK_LOG"
+}
+
+# ------------------------------------------------------------------
+# install_mise_and_languages は INSTALL_BUN に影響されない
+# （bun は別関数。INSTALL_NODE / INSTALL_PYTHON 双方 OFF なら no-op のまま）
+# ------------------------------------------------------------------
+
+@test "install_mise_and_languages: INSTALL_BUN does not trigger node/python path" {
+  export INSTALL_BUN=1
+  export INSTALL_NODE=0
+  export INSTALL_PYTHON=0
+
+  run install_mise_and_languages
+  [ "$status" -eq 0 ]
+  [ ! -s "$MOCK_LOG" ]
+}


### PR DESCRIPTION
## 背景

`suasor`（Bun-native な MCP サーバ。`bun:sqlite` を使い `npx`/Node では動かない）など、Bun-native ツールをホスト直で動かす需要がある。agentyard は Node LTS + pnpm を入れるが Bun は未対応だった。

「agent を用いたモダン開発の baseline か」という観点では、MCP/agent エコシステムの主流は依然 Node + `npx` のため Bun は **既定 ON にはしない**。一方で Bun-native MCP サーバは確立しつつあるカテゴリであり、AI-first を掲げる agentyard の **opt-in** としては妥当と判断した。

## 変更

`INSTALL_BUN`（既定 OFF）で Bun を opt-in 導入する。Node + pnpm の置き換えではなく**追加**の選択肢。

- `scripts/lib/install-languages.sh`: `install_bun()` を追加（`mise_use_global "bun@1"`）
- `scripts/setup-local-linux.sh`: フラグ / 対話プロンプト / サマリ行 / 呼び出し配線
- `scripts/setup-local-macos.sh`: フラグ / inline `install_bun` / サマリ行 / 呼び出し配線
- `README.md` / `README.ja.md`: env-var テーブル × 2、機能リストを同期
- `docs/adr/ADR-0002`: 採用理由・ピン運用・真の opt-in 設計を追記
- `tests/unit/install-languages.bats`: `install_bun` のユニットテスト（新規）
- `tests/integration/{assert-tools,entrypoint}.sh`: 3rd run に `INSTALL_BUN=1` を追加し gated アサーション

## 設計上のポイント

1. **mise core backend → レンジ指定**: bun は core backend 扱いのため node/python と同じ `bun@1` のレンジ運用に乗る。aqua レジストリの追従ずれ・具体パッチ版ピン・Renovate churn の対象外。
2. **真の opt-in（global config テンプレート非掲載）**: `dotfiles/.../mise/config.toml` に列挙すると `install_dev_tools` 末尾の `mise install` で**全ホストに入り opt-in でなくなる**（trivy が同経路で全員に入るのと同じ）。これを避けテンプレートに**列挙しない**。一方 `chezmoi apply` は global config を上書きするため、apply 前に登録すると wipe される（ADR-0003 / #153・#156）。対策として `install_bun` を **`install_dev_tools`（最後の chezmoi apply）より後**に呼び、wipe を回避しつつ非掲載を両立する。
3. **doctor 非対象**: opt-in のため `check_mise_managed_tools` の必須リストには含めない（zellij と同じ。含めると未導入ホストで誤 warning）。

## 検証

- `shfmt -d` / `shellcheck --severity=warning`: クリーン
- `bats tests/unit/`: 84/84 pass（新規 `install_bun` テスト 4 件含む）
- `markdownlint-cli2`: 0 errors
- lefthook pre-commit 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)