### PR TITLE
fix: run chezmoi apply non-interactively (--force) in all modes

### DIFF
--- a/docs/adr/ADR-0003-config-management-policy.md
+++ b/docs/adr/ADR-0003-config-management-policy.md
@@ -14,7 +14,17 @@ OzzyLabs 推奨のドットファイル設定をユーザー環境に適用す�
 
 - **chezmoi**: テンプレートベースの設定管理。
 - **Auto (-y)**: 質問なしで推奨設定を適用（CI や新規構築用）。
-- **Interactive**: 各項目の適用をユーザーに確認（既存環境用）。
+- **Interactive**: インストール対象カテゴリの選択をユーザーに確認（既存環境用）。
+
+### chezmoi apply は常に非対話（`--force`）で実行する
+
+> 改訂（2026-06-16）: 当初は Interactive モードで `chezmoi apply --interactive`（適用ファイルごとに `Apply <file>?` と確認）を使っていたが、これを廃し **モードを問わず常に `chezmoi apply --force`** とする。
+
+- **理由**: `--interactive` の per-file prompt は、`curl … | bash` でカテゴリ選択を `y` で進めたユーザーにとって、スクリプト本体の `[Y/n]` プロンプトとは異なる見慣れない UI として現れ、「ハングした」と誤認させる UX トラップになっていた（インストーラがそこで停止したように見える）。
+- 「Interactive モード」は引き続き有効だが、その対話性が支配するのは **インストール対象カテゴリの選択プロンプト**（`scripts/lib/prompts.sh` の `_prompt_*`）であり、`chezmoi apply` ステップ自体は対象外とする。
+- **安全性の担保**: インストーラのこのステップに到達した時点で「推奨 dotfiles を適用する」意思は確認済みとみなせる。既存の `.zshrc` 等は `~/.zshrc.d/` 機構（下記「影響」）で破壊されない。適用後の差分は `./install.sh doctor`（`check_chezmoi_drift`）で随時確認・再適用できる。
+- 個別レビューしながら適用したい上級者は、セットアップ後に手動で `chezmoi apply --interactive --source <dotfiles>` を実行すればよい。
+- 実装: `scripts/lib/install-dev.sh`（Linux）/ `scripts/setup-local-macos.sh`（macOS）の両 `install_dev_tools`。
 
 ## 理由
 

--- a/scripts/lib/install-dev.sh
+++ b/scripts/lib/install-dev.sh
@@ -43,13 +43,17 @@ fi' "~/.zshrc に ~/.zshrc.d/ の読み込み設定を追加しました"
   if [ -d "$repo_root/dotfiles" ]; then
     echo ""
     echo "🏠 chezmoi で推奨設定を適用中..."
-    # --force: 既存ファイルを上書き（chezmoi は内部でバックアップを保持する）
-    # --source: リポジトリ内の dotfiles ディレクトリを指定
-    if _is_non_interactive; then
-      _mise_at_home exec chezmoi -- chezmoi apply --force --source "$repo_root/dotfiles"
-    else
-      _mise_at_home exec chezmoi -- chezmoi apply --interactive --source "$repo_root/dotfiles"
-    fi
+    # chezmoi apply は対話モード/非対話モードを問わず常に --force（非対話）で実行する。
+    # 以前は interactive モードで `--interactive` を使っていたが、これは適用ファイル
+    # ごとに `Apply <file>?` と尋ねるため、curl|bash でカテゴリ選択を y で進めた
+    # ユーザーが見慣れない prompt を「ハング」と誤認して停止する UX トラップになって
+    # いた。インストーラのこのステップに到達した時点で「推奨 dotfiles を適用する」
+    # 意思は確認済みとみなせること、既存 shell 設定は ~/.zshrc.d/ 機構で保護済みで
+    # あること、適用後の差分は `./install.sh doctor`（check_chezmoi_drift）で確認可能
+    # であることから、chezmoi apply 自体は常に非対話とする。ADR-0003 参照。
+    # （スクリプトのカテゴリ選択プロンプトの対話性は従来どおり維持される）
+    # --force: 既存ファイルを上書き / --source: リポジトリ内 dotfiles を指定
+    _mise_at_home exec chezmoi -- chezmoi apply --force --source "$repo_root/dotfiles"
     echo "  ✅ chezmoi による設定適用完了"
 
     # chezmoi apply で書き出された ~/.config/mise/config.toml に宣言されているが

--- a/scripts/setup-local-macos.sh
+++ b/scripts/setup-local-macos.sh
@@ -187,11 +187,11 @@ fi' "~/.zshrc に ~/.zshrc.d/ の読み込み設定を追加しました"
   if [ -d "$repo_root/dotfiles" ]; then
     echo ""
     echo "🏠 chezmoi で推奨設定を適用中..."
-    if _is_non_interactive; then
-      _mise_at_home exec chezmoi -- chezmoi apply --force --source "$repo_root/dotfiles"
-    else
-      _mise_at_home exec chezmoi -- chezmoi apply --interactive --source "$repo_root/dotfiles"
-    fi
+    # chezmoi apply は対話/非対話を問わず常に --force（非対話）で実行する。
+    # `--interactive` の per-file prompt（`Apply <file>?`）が curl|bash ユーザーの
+    # 停止トラップになっていたため。詳細は Linux 側 scripts/lib/install-dev.sh の
+    # 同ブロックのコメントと ADR-0003 を参照。
+    _mise_at_home exec chezmoi -- chezmoi apply --force --source "$repo_root/dotfiles"
     echo "  ✅ chezmoi による設定適用完了"
 
     # chezmoi apply で書き出された ~/.config/mise/config.toml に宣言されているが


### PR DESCRIPTION
## 背景

`curl -fsSL .../install.sh | bash` を実行しカテゴリ選択を `y` で進めたユーザーが、開発補助ツール導入の最後で次の表示のまま停止する事象が報告された:

```
🏠 chezmoi で推奨設定を適用中...
Apply .config/mise/config.toml?
```

原因は `install_dev_tools` が interactive モードで `chezmoi apply --interactive` を呼んでおり、適用ファイルごとに `Apply <file>?` と確認していたこと。これはハングではなく chezmoi の入力待ちだが、スクリプト本体の `[Y/n]` とは異なる見慣れない prompt のため「止まった」と誤認される UX トラップだった。

## 変更

`chezmoi apply` を **対話/非対話モードを問わず常に `--force`（非対話）** で実行する。

- `scripts/lib/install-dev.sh`（Linux）/ `scripts/setup-local-macos.sh`（macOS）の `install_dev_tools` から `if _is_non_interactive` 分岐を除去し `--force` に統一。
- `docs/adr/ADR-0003` に改訂を記録（Interactive モードはカテゴリ選択の対話性を支配するが、chezmoi apply 自体は常に非対話）。

## 根拠（安全性）

- インストーラのこのステップ到達 = 「推奨 dotfiles を適用する」意思は確認済みとみなせる。
- 既存 `.zshrc` 等は `~/.zshrc.d/` 機構で破壊されない（ADR-0003）。
- 適用後の差分は `./install.sh doctor`（`check_chezmoi_drift`）で随時確認・再適用可能。
- 個別レビューしたい上級者は手動で `chezmoi apply --interactive` を実行可能。
- CI は元々 `CI=true` で非対話（既に `--force`）のため挙動不変。

## 検証

shfmt / shellcheck / markdownlint クリーン、bats 84/84 pass。

🤖 Generated with [Claude Code](https://claude.com/claude-code)