### PR TITLE
ci: fix MISE_DISABLE_TOOLS to actually exclude trivy

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -17,6 +17,11 @@ jobs:
   lint:
     name: Static analysis (shellcheck / shfmt / markdownlint / yaml / gitleaks)
     runs-on: ubuntu-latest
+    # Job-level so every `mise exec` step (not just mise-action setup) skips trivy.
+    # trivy's github: backend triggers attestation verification against aquasecurity's
+    # IP-allowlisted API (403 in CI); trivy is only needed by the local pre-commit hook.
+    env:
+      MISE_DISABLE_TOOLS: "github:aquasecurity/trivy"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -28,7 +33,6 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          MISE_DISABLE_TOOLS: "github:aquasecurity/trivy"
 
       - name: shellcheck
         run: |

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -28,7 +28,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          MISE_DISABLE_TOOLS: trivy
+          MISE_DISABLE_TOOLS: "github:aquasecurity/trivy"
 
       - name: shellcheck
         run: |

--- a/.github/workflows/test-smoke.yaml
+++ b/.github/workflows/test-smoke.yaml
@@ -18,6 +18,11 @@ jobs:
     name: Smoke tests (CLI entry points)
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    # Job-level so every `mise exec` step (not just mise-action setup) skips trivy.
+    # trivy's github: backend triggers attestation verification against aquasecurity's
+    # IP-allowlisted API (403 in CI); trivy is only needed by the local pre-commit hook.
+    env:
+      MISE_DISABLE_TOOLS: "github:aquasecurity/trivy"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -29,7 +34,6 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          MISE_DISABLE_TOOLS: "github:aquasecurity/trivy"
 
       - name: Run smoke tests
         run: ./tests/smoke/run.sh

--- a/.github/workflows/test-smoke.yaml
+++ b/.github/workflows/test-smoke.yaml
@@ -29,7 +29,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          MISE_DISABLE_TOOLS: trivy
+          MISE_DISABLE_TOOLS: "github:aquasecurity/trivy"
 
       - name: Run smoke tests
         run: ./tests/smoke/run.sh

--- a/.github/workflows/test-unit.yaml
+++ b/.github/workflows/test-unit.yaml
@@ -18,6 +18,11 @@ jobs:
     name: BATS unit tests
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    # Job-level so every `mise exec` step (not just mise-action setup) skips trivy.
+    # trivy's github: backend triggers attestation verification against aquasecurity's
+    # IP-allowlisted API (403 in CI); trivy is only needed by the local pre-commit hook.
+    env:
+      MISE_DISABLE_TOOLS: "github:aquasecurity/trivy"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -29,7 +34,6 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          MISE_DISABLE_TOOLS: "github:aquasecurity/trivy"
 
       - name: Run BATS unit tests
         run: mise exec -- bats tests/unit/

--- a/.github/workflows/test-unit.yaml
+++ b/.github/workflows/test-unit.yaml
@@ -29,7 +29,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          MISE_DISABLE_TOOLS: trivy
+          MISE_DISABLE_TOOLS: "github:aquasecurity/trivy"
 
       - name: Run BATS unit tests
         run: mise exec -- bats tests/unit/


### PR DESCRIPTION
## 問題

CI の全 job（BATS unit / Smoke / Static analysis）が **mise setup 段で失敗**していた:

```
mise ERROR Failed to install github:aquasecurity/trivy@0.70.0:
GitHub artifact attestations verification error ... 403 Forbidden ...
aquasecurity organization has an IP allow list enabled
```

各 job は回避のため `MISE_DISABLE_TOOLS: trivy` を設定していたが、**tool 名にマッチしていなかった**。tool は `.mise.toml` で `github:aquasecurity/trivy` として宣言されているため、`trivy` では除外されず mise が install→attestation 検証→403 を起こしていた。

## 修正

tool のフルネームを指定:

```diff
- MISE_DISABLE_TOOLS: trivy
+ MISE_DISABLE_TOOLS: "github:aquasecurity/trivy"
```

`mise ls` で `github:aquasecurity/trivy` 指定時のみ当該 tool が除外されることを実測確認。trivy は CI では不要（pre-commit フック用にのみ宣言）。

## 影響

lint / test-smoke / test-unit の 3 workflow。この PR の CI 自体が green になれば修正が効いている証左。

🤖 Generated with [Claude Code](https://claude.com/claude-code)