### PR TITLE
fix: gate pre-commit trivy on high/critical severity

### DIFF
--- a/lefthook-base.yaml
+++ b/lefthook-base.yaml
@@ -60,4 +60,7 @@ pre-commit:
     gitleaks:
       run: mise exec -- gitleaks protect --staged --no-banner
     trivy:
-      run: mise exec -- trivy fs --scanners vuln,secret --exit-code 1 --no-progress .
+      # Pre-commit gate: fail only on HIGH/CRITICAL vulnerabilities. A pre-existing
+      # LOW/MEDIUM/UNKNOWN (or fix-unavailable) advisory in a dependency must not
+      # block every unrelated commit; those are surfaced by CI / Dependabot instead.
+      run: mise exec -- trivy fs --scanners vuln,secret --severity HIGH,CRITICAL --exit-code 1 --no-progress .

--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -34,4 +34,4 @@ pre-commit:
       run: "true"
       skip: true
     agentyard-trivy:
-      run: mise exec -- trivy fs --scanners vuln --exit-code 1 --no-progress .
+      run: mise exec -- trivy fs --scanners vuln --severity HIGH,CRITICAL --exit-code 1 --no-progress .


### PR DESCRIPTION
pre-commit の trivy hook（base + agentyard-trivy）を HIGH/CRITICAL のみ fail に変更（commons #154 と整合）。severity 未指定だと LOW/修正不能 advisory でも全 commit がブロックされる問題を解消。

🤖 Generated with [Claude Code](https://claude.com/claude-code)